### PR TITLE
Remove engineering as a CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-*                                    @MetaMask/engineering


### PR DESCRIPTION
## Context
GitHub codeowners allow us to ensure that a specific group of people with write access are able to gate whether or not a pull request is allowed to be merged. It does this by adding them as a reviewer to every PR touching the designated files.

## Problem
The problem with adding engineering as a codeowner is that each time a pull request in this repo is made, every member of our engineering team is hit with a notification. While codeowners make sense in cases where we want a specified group to gate changes, it becomes redundant where the code owning group is the entire engineering team.

## Solution
Remove the code owner, and instead ensure that 1 approval is required before a pull request can be merged. This means that we still enforce a member of our engineering team to approve the pull request prior to a change being made, but now we are not sending review request notifications to everyone. 