### PR TITLE
Remove code and config specific to module template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,11 +9,3 @@ Are there any issues or other links reviewers should consult to understand this 
 * Fixes #12345
 * See: #67890
 -->
-
-## Examples
-
-<!--
-Are there any examples of this change being used in another repository?
-
-When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
--->

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,9 +42,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 0,
-      functions: 12.5,
-      lines: 4.16,
-      statements: 4.16,
+      functions: 0,
+      lines: 0,
+      statements: 0,
     },
   },
 
@@ -95,6 +95,9 @@ module.exports = {
 
   // An enum that specifies notification mode. Requires { notify: true }
   // notifyMode: "failure-change",
+
+  // TODO: We don't have any tests right now, but we should add them.
+  passWithNoTests: true,
 
   // A preset that is used as a base for Jest's configuration
   preset: 'ts-jest',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,0 @@
-import greeter from '.';
-
-describe('Test', () => {
-  it('greets', () => {
-    const name = 'Huey';
-    const result = greeter(name);
-    expect(result).toBe('Hello, Huey!');
-  });
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,0 @@
-/**
- * Example function that returns a greeting for the given name.
- *
- * @param name - The name to greet.
- * @returns The greeting.
- */
-export default function greeter(name: string): string {
-  return `Hello, ${name}!`;
-}


### PR DESCRIPTION
- The `index.ts` and `index.test.ts` files in `src/` exist in the module template as examples, but we don't need them here.
- Since we don't have any real tests in this repo at the moment, we need to tell Jest it's okay to run without tests and that coverage is 0%.
- The Examples section in the PR template is specific to the module template and shouldn't be in derivative repos.