### PR TITLE
feat: add team label reusable workflow

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,17 @@
+name: Setup environment
+description: Setup environment
+runs:
+  using: composite
+  steps:
+    - run: corepack enable
+      shell: bash
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .nvmrc
+        cache: yarn
+
+    - name: Install dependencies
+      run: yarn --immutable
+      shell: bash

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: ./.github/actions/setup-environment
+        uses: metamask/github-tools/.github/actions/setup-environment@add-team-label-reusable-workflow
 
       - name: Add team label
         env:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: metamask/github-tools/.github/actions/setup-environment@add-team-label-reusable-workflow
+        uses: metamask/github-tools/.github/actions/setup-environment@main
 
       - name: Add team label
         env:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -1,0 +1,22 @@
+name: Add team label
+
+on:
+  workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  add-team-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Add team label
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: yarn run add-team-label

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup environment
-        uses: metamask/github-tools/.github/actions/setup-environment@add-team-label-reusable-workflow
+        uses: ./.github/actions/setup-environment
 
       - run: yarn lint
       
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup environment
-        uses: metamask/github-tools/.github/actions/setup-environment@add-team-label-reusable-workflow
+        uses: ./.github/actions/setup-environment
 
       - run: yarn test
 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,12 +9,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
       - run: yarn lint
-      
+
       - name: Require clean working directory
         shell: bash
         run: |
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -4,33 +4,17 @@ on:
   workflow_call:
 
 jobs:
-  prepare:
-    name: Prepare
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: Install Yarn dependencies
-        run: yarn --immutable
-
   lint:
-    name: Lint
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup environment
+        uses: metamask/github-tools/.github/actions/setup-environment@add-team-label-reusable-workflow
+
       - run: yarn lint
+      
       - name: Require clean working directory
         shell: bash
         run: |
@@ -40,19 +24,16 @@ jobs:
           fi
 
   test:
-    name: Test
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup environment
+        uses: metamask/github-tools/.github/actions/setup-environment@add-team-label-reusable-workflow
+
       - run: yarn test
+
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,14 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
         shell: bash
+
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,8 +10,8 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
+    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
   - path: .yarn/plugins/@yarnpkg/plugin-constraints.cjs
-    spec: "@yarnpkg/plugin-constraints"
+    spec: '@yarnpkg/plugin-constraints'
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Instead of copy-pasting the implementation of add-team-label to other repositories, such as metamask-extension and metamask-mobile, it should be possible to call the workflow directly from the github-tools repository, if we make it a reusable workflow. This is great, because if we make a change to the workflow in the github-tools repository, the changes propagate to other repositories as well.

More information about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows

This kind of aligns with https://github.com/MetaMask/metamask-extension/issues/25509, but not exactly. The shared library would still be needed nevertheless, as this is only sharing the workflow definition, but not the scripts that are run during the workflow. The scripts still need to exist in all the repositories (for now). Ideally, we would make the shared library an npm package that can be installed in the different repositories to allow for the sharing of scripts.

Resolves: https://github.com/MetaMask/MetaMask-planning/issues/2760