### PR TITLE
revert: Enable benchmarks in metamask-extension (#38)

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -3,10 +3,7 @@ description: Setup environment
 runs:
   using: composite
   steps:
-    # If it's in a container, `corepack enable` will only run with `sudo`
-    # (This uses the documented way to write a ternary operator in GHA:
-    #  https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example)
-    - run: ${{ job.container && 'sudo' || '' }} corepack enable
+    - run: corepack enable
       shell: bash
 
     - name: Set up Node.js

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -17,6 +17,5 @@ jobs:
         shell: bash
 
       - name: Lint workflow files
-        # The ignore is necessary because `gha-mm-scale-set-ubuntu-22.04-amd64-med` is unknown
-        run: ${{ steps.download-actionlint.outputs.executable }} -color -ignore 'label ".+" is unknown'
+        run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash


### PR DESCRIPTION
The previous PR made two changes, both of which are no longer needed, at least for the moment:

**Not using containers at the moment**
Using `ubuntu-22.04` with no container instead
```
- run: ${{ job.container && 'sudo' || '' }} corepack enable
```

**Not using self-hosted runners at the moment**
GitHub-hosted runners seem sufficient
```
# The ignore is necessary because `gha-mm-scale-set-ubuntu-22.04-amd64-med` is unknown
run: ${{ steps.download-actionlint.outputs.executable }} -color -ignore 'label ".+" is unknown'
```