### PR TITLE
feat(projects): Add issues and PRs to github projects by team

### DIFF
--- a/.github/workflows/add-item-to-project.yml
+++ b/.github/workflows/add-item-to-project.yml
@@ -1,18 +1,18 @@
-name: "Add Issue/PR to Project by team"
+name: 'Add Issue/PR to Project by team'
 
 on:
   workflow_call:
     inputs:
       project-url:
-        description: "URL of the GitHub Project where items should be added"
+        description: 'URL of the GitHub Project where items should be added'
         required: true
         type: string
       team-name:
-        description: "Team name to match for PR review_requested or requested_team"
+        description: 'Team name to match for PR review_requested or requested_team'
         required: true
         type: string
       team-label:
-        description: "Label that indicates the Issue/PR belongs to the team"
+        description: 'Label that indicates the Issue/PR belongs to the team'
         required: true
         type: string
     secrets:
@@ -21,7 +21,7 @@ on:
 
 jobs:
   add_to_project:
-    name: "Add to Project Board"
+    name: 'Add to Project Board'
     runs-on: ubuntu-latest
 
     # Ensure we have permissions to read issues/PRs and create project issues

--- a/.github/workflows/add-item-to-project.yml
+++ b/.github/workflows/add-item-to-project.yml
@@ -1,0 +1,55 @@
+name: "Add Issue/PR to Project by team"
+
+on:
+  workflow_call:
+    inputs:
+      project-url:
+        description: "URL of the GitHub Project where items should be added"
+        required: true
+        type: string
+      team-name:
+        description: "Team name to match for PR review_requested or requested_team"
+        required: true
+        type: string
+      team-label:
+        description: "Label that indicates the Issue/PR belongs to the team"
+        required: true
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  add_to_project:
+    name: "Add to Project Board"
+    runs-on: ubuntu-latest
+
+    # Ensure we have permissions to read issues/PRs and create project issues
+    # (some repos may need 'contents: read', 'issues: write', 'pull-requests: write', etc.)
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      # If you are using "classic" Projects, also add: projects: write
+
+    steps:
+      - name: Add item to project board
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+        if: |
+          (github.event_name == 'pull_request' &&
+            (
+              github.event.requested_team.name == inputs.team-name ||
+              contains(github.event.pull_request.labels.*.name, inputs.team-label) ||
+              contains(github.event.pull_request.requested_teams.*.name, inputs.team-name)
+            )
+          )
+          || 
+          (github.event_name == 'issues' &&
+            (
+              contains(github.event.issue.labels.*.name, inputs.team-label)
+            )
+          )
+        with:
+          project-url: ${{ inputs.project-url }}
+          # The reusable workflow automatically receives the calling workflow's GITHUB_TOKEN
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Teams like the Wallet Framework team have a ton of repos under our care and for this reason we need to be able to auto add issues/PRs to our project board across all those repos. The github projects built in workflow only allows for up to 20 workflows which isn't enough to cover all the repos we have so we are creating a shared workflow that we can use across many repos in order to do the above. 

Any team can use this workflow by passing the project url and team name information. 
