### PR TITLE
fix(actions): Remove GH Token from secrets it gets it automatically

### DIFF
--- a/.github/workflows/add-item-to-project.yml
+++ b/.github/workflows/add-item-to-project.yml
@@ -15,9 +15,6 @@ on:
         description: 'Label that indicates the Issue/PR belongs to the team'
         required: true
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   add_to_project:


### PR DESCRIPTION
I mistakenly thought I had to include the github token in the secrets that the workflow accepts. It gets it automatically. Additionally having the secrets input defined as expecting GH Token causes an issue because GH Token is reserved 
