### PR TITLE
fix: add proper secrets definition to `add item to project`  workflow

### DIFF
--- a/.github/workflows/add-item-to-project.yml
+++ b/.github/workflows/add-item-to-project.yml
@@ -15,6 +15,10 @@ on:
         description: 'Label that indicates the Issue/PR belongs to the team'
         required: true
         type: string
+    secrets:
+      github-token:
+        description: 'GitHub token with permissions to add items to projects'
+        required: true
 
 jobs:
   add_to_project:
@@ -40,7 +44,7 @@ jobs:
               contains(github.event.pull_request.requested_teams.*.name, inputs.team-name)
             )
           )
-          || 
+          ||
           (github.event_name == 'issues' &&
             (
               contains(github.event.issue.labels.*.name, inputs.team-label)
@@ -48,5 +52,4 @@ jobs:
           )
         with:
           project-url: ${{ inputs.project-url }}
-          # The reusable workflow automatically receives the calling workflow's GITHUB_TOKEN
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.github-token }}


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
## Description

This PR fixes an issue with the reusable workflow for adding issues and PRs to project boards. The workflow was attempting to use a GitHub token passed from calling workflows, but didn't properly define the secrets input in the `workflow_call` section.

### Changes

- Added a `secrets` section to the `workflow_call` definition
- Properly defined the `github-token` secret with description and required flag
- Ensured consistent naming between the defined secret and its usage in the action
