### PR TITLE
feat: improve changelog check workflow

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: MetaMask/github-tools
-          ref: main
+          ref: ${{ github.sha }}
           path: github-tools
 
       - name: Enable Corepack


### PR DESCRIPTION
## Description
This PR improves the changelog check workflow in two ways:

1. **Skip package.json version-only changes**: The changelog check will now skip package.json files that only contain version changes, reducing unnecessary changelog requirements for simple version bumps.

2. **Fix workflow reference**: Changed the workflow checkout to use the same commit SHA that's referenced in the workflow call instead of `main`, preventing potential issues from breaking changes in the main branch.

## Testing
### Package.json Version Skip Testing
1. Using [Core](https://github.com/MetaMask/core) monorepo:
   ```bash
   # Checkout the release branch https://github.com/MetaMask/core/pull/5690
   git checkout release/372.0.0
   
   # Test with current main version (should fail)
   copy https://github.com/MetaMask/github-tools/blob/main/src/changelog-check.ts file to scripts folder
   # Change the import of execa from { execa } to execa
   # Add the script "changelog:check": "ts-node scripts/changelog-check.ts" to package.json
   yarn changelog:check . main 5690
   # This should fail as it would require a changelog for phishing-controller
   
   # Test with new version in this PR (should pass)
   copy https://github.com/MetaMask/github-tools/blob/ce4ba9de297920ebcfacb2465e6f552baf255b8a/src/changelog-check.ts to scripts folder
   # Change the import of execa from { execa } to execa
   yarn changelog:check . main 5690
   # The script should complete without requiring changelog entry for phishing-controller for PR 5690
   ```

Fixes https://github.com/MetaMask/github-tools/issues/60