### PR TITLE
fix(changelog-check): use correct reference in workflow checkout

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: MetaMask/github-tools
-          ref: ${{ github.sha }}
+          ref: ${{ github.action_ref }}
           path: github-tools
 
       - name: Enable Corepack


### PR DESCRIPTION
## Description
This PR fixes the workflow checkout reference issue in the changelog check workflow. Previously, the workflow was using `${{ github.sha }}`([here](https://github.com/MetaMask/core/actions/runs/14605760515/job/40974318922?pr=5693)) which caused a "not our ref" error because it was trying to use the current workflow run's SHA instead of the reference used to call the workflow.

## Changes
- Updated workflow checkout to use `${{ github.action_ref }}` to match the reference used in the workflow call
- This ensures the workflow uses the same reference (SHA or branch) that was specified in the workflow call