### PR TITLE
chore(changelog-check): add action-sha input for correct repository checkout

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       action-sha:
         description: 'The SHA of the action to use'
-        required: false
+        required: true
         type: string
       base-branch:
         required: false
@@ -56,18 +56,12 @@ jobs:
           path: target-repo
           fetch-depth: 0
 
-      - name: Debug Action SHA
-        if: ${{ steps.label-check.outputs.skip_check != 'true' }}
-        run: |
-          echo "Action SHA: ${{ inputs.action-sha || 'main' }}"
-        shell: bash
-
       - name: Checkout github-tools repository
         if: ${{ steps.label-check.outputs.skip_check != 'true' }}
         uses: actions/checkout@v4
         with:
           repository: MetaMask/github-tools
-          ref: ${{ inputs.action-sha || 'main' }}
+          ref: ${{ inputs.action-sha }}
           path: github-tools
 
       - name: Enable Corepack

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -3,6 +3,10 @@ name: Check Changelog
 on:
   workflow_call:
     inputs:
+      action-sha:
+        description: 'The SHA of the action to use'
+        required: false
+        type: string
       base-branch:
         required: false
         type: string
@@ -55,7 +59,7 @@ jobs:
       - name: Debug Action SHA
         if: ${{ steps.label-check.outputs.skip_check != 'true' }}
         run: |
-          echo "Action SHA: ${{ github.action_sha }}"
+          echo "Action SHA: ${{ inputs.action-sha }}"
         shell: bash
 
       - name: Checkout github-tools repository
@@ -63,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: MetaMask/github-tools
-          ref: ${{ github.action_sha }}
+          ref: ${{ inputs.action-sha || 'main' }}
           path: github-tools
 
       - name: Enable Corepack

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Debug Action SHA
         if: ${{ steps.label-check.outputs.skip_check != 'true' }}
         run: |
-          echo "Action SHA: ${{ inputs.action-sha }}"
+          echo "Action SHA: ${{ inputs.action-sha || 'main' }}"
         shell: bash
 
       - name: Checkout github-tools repository

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: MetaMask/github-tools
-          ref: ${{ github.action_ref }}
+          ref: ${{ github.action_sha }}
           path: github-tools
 
       - name: Enable Corepack

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -52,6 +52,12 @@ jobs:
           path: target-repo
           fetch-depth: 0
 
+      - name: Debug Action SHA
+        if: ${{ steps.label-check.outputs.skip_check != 'true' }}
+        run: |
+          echo "Action SHA: ${{ github.action_sha }}"
+        shell: bash
+
       - name: Checkout github-tools repository
         if: ${{ steps.label-check.outputs.skip_check != 'true' }}
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
This PR adds an `action-sha` input to the changelog check workflow to ensure we're using the correct version of the github-tools repository. This is necessary because:

1. When a workflow is called using a specific SHA (e.g., `@91e349d177db2c569e03c7aa69d2acb404b62f75`), we need to use that exact same SHA when checking out the repository
2. Previous attempts using `github.action_ref`, `github.sha`, or other GitHub context variables didn't work because:
   - `github.action_ref` includes the full ref path (e.g., `+refs/heads/v4*:refs/remotes/origin/v4*`)
   - `github.sha` refers to the current workflow run's SHA
   - Other context variables don't reliably provide the correct SHA

### Long-term Plan
This is a short-term fix. In the future, we plan to:
1. Move the workflow to a separate repository
2. Implement proper versioning for the tools
3. Use GitHub Actions' built-in versioning system
4. Remove the need for manual SHA management

## Changes
- Added new required input `action-sha` to the workflow
- Updated the checkout step to use `${{ inputs.action-sha }}`
- This ensures we're using the exact same version that was specified in the workflow call

## Testing
1. This change is being tested in [MetaMask/core#5693](https://github.com/MetaMask/core/pull/5693) where we're updating the changelog check workflow to use the new `action-sha` input.

2. Test with a workflow call using a specific SHA:
   ```yaml
   uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@91e349d177db2c569e03c7aa69d2acb404b62f75
   with:
     action-sha: 91e349d177db2c569e03c7aa69d2acb404b62f75
     # ... other inputs ...
   ```
   - Verify that the workflow successfully checks out the correct SHA

3. Verify that the checkout works correctly and matches the version used in the workflow call