### PR TITLE
chore(changelog-check): exclude private packages from changelog check

### DIFF
--- a/src/changelog-check.ts
+++ b/src/changelog-check.ts
@@ -165,15 +165,18 @@ async function isVersionOnlyChange(
  * Checks if a package is marked as private in its package.json.
  *
  * @param repoPath - The path to the repository.
- * @param filePath - The path to the package.json file.
+ * @param packageJsonPath - The path to the package.json file.
  * @returns Promise that resolves to true if the package is private, false otherwise.
  */
 async function isPrivatePackage(
   repoPath: string,
-  filePath: string,
+  packageJsonPath: string,
 ): Promise<boolean> {
   try {
-    const content = await fs.readFile(path.join(repoPath, filePath), 'utf-8');
+    const content = await fs.readFile(
+      path.join(repoPath, packageJsonPath),
+      'utf-8',
+    );
     const packageJson = JSON.parse(content) as PackageJson;
     return packageJson.private === true;
   } catch (error) {
@@ -256,10 +259,8 @@ async function getChangedPackages(
 
     const packageInfo = getPackageInfo(file, workspacePatterns);
     if (packageInfo) {
-      // Check if we've already determined if this package is private
       let isPrivate = privatePackageCache.get(packageInfo.package);
       if (isPrivate === undefined) {
-        // If not in cache, check and cache the result
         const packageJsonPath = path.join(
           packageInfo.base,
           packageInfo.package,


### PR DESCRIPTION
## Description
This PR adds support for excluding private packages from the changelog check workflow. Private packages in a monorepo typically don't require public changelog entries since they are not published to npm.

## Changes
- Added `isPrivatePackage` function to detect private packages by checking the `private` field in package.json
- Added caching for private package checks to optimize performance when multiple files in the same package are changed
- Modified `getChangedPackages` to skip private packages regardless of which files were changed
- Added logging when private packages are skipped for better visibility

### Testing Steps
1. Using [Core](https://github.com/MetaMask/core) monorepo:
   - First, make the `phishing-controller` package private by adding `"private": true` to its package.json
   - Make dummy changes to `packages/phishing-controller/src/PhishingController.ts`:
     ```typescript
     // Add a dummy comment or empty line to trigger changes
     // This is a test change for private package changelog check
     ```
   - Commit the changes

2. Test with current main version (should fail):
   ```bash
   # Manually copy the current changelog check script
   cp .github/workflows/changelog-check.ts (from github-tools) scripts/ (to core)
   
   # Update the execa import
   sed -i '' 's/import { execa }/import execa/' scripts/changelog-check.ts
   
   # Manually add the following to package.json under the scripts section:
   # "changelog:check": "ts-node scripts/changelog-check.ts"
   
   # Run the check
   yarn changelog:check . main 5690
   # This should fail, requiring a changelog for the private package
   ```

3. Test with new version (should pass):
   ```bash
   # Manually copy the updated changelog check script
   cp .github/workflows/changelog-check.ts (from github-tools) scripts/ (to core)
   
   # Update the execa import
   sed -i '' 's/import { execa }/import execa/' scripts/changelog-check.ts
   
   # Run the check
   yarn changelog:check . main 5690
   # This should pass, skipping the private package without requiring a changelog
   ```

Expected Results:
- Current version: Fails, requiring changelog for private package
- New version: Passes, skipping private package changelog requirement