### PR TITLE
chore: update stale bot to process only issues with needs-information, needs-reproduction label

### DIFF
--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -26,7 +26,7 @@ on:
       exempt_issue_labels:
         description: 'Comma-separated list of labels that exempt issues from being marked as stale'
         required: false
-        default: 'type-security, feature-request, Sev1-high, needs-triage, external-contributor'
+        default: 'type-security, feature-request, Sev1-high, needs-triage'
         type: string
       days_before_issue_stale:
         description: 'Number of days of inactivity before an issue becomes stale'

--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -21,7 +21,7 @@ on:
       any_of_issue_labels:
         description: 'Comma-separated list of labels to check for issues'
         required: false
-        default: 'type-bug, needs-information, needs-reproduction'
+        default: 'needs-information, needs-reproduction'
         type: string
       exempt_issue_labels:
         description: 'Comma-separated list of labels that exempt issues from being marked as stale'

--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -26,7 +26,7 @@ on:
       exempt_issue_labels:
         description: 'Comma-separated list of labels that exempt issues from being marked as stale'
         required: false
-        default: 'type-security, feature-request, Sev1-high, needs-triage'
+        default: 'type-security, feature-request, Sev1-high, needs-triage, external-contributor'
         type: string
       days_before_issue_stale:
         description: 'Number of days of inactivity before an issue becomes stale'


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

update stale bot to process only issues with needs-information, needs-reproduction label