### PR TITLE
feat: add workflow to upload Yarn binary to GitHub Release

### DIFF
--- a/.github/workflows/upload-yarn-binary.yml
+++ b/.github/workflows/upload-yarn-binary.yml
@@ -1,0 +1,54 @@
+name: Upload Yarn Binary to GitHub Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      yarn_version:
+        description: 'Yarn version to upload (e.g., 4.9.1)'
+        required: true
+        type: string
+
+jobs:
+  upload-yarn-binary:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Set up variables
+        id: vars
+        run: |
+          echo "YARN_VERSION=${{ github.event.inputs.yarn_version }}" >> $GITHUB_ENV
+          echo "YARN_FILENAME=yarn-${{ github.event.inputs.yarn_version }}.js" >> $GITHUB_ENV
+          echo "RELEASE_TAG=v${{ github.event.inputs.yarn_version }}" >> $GITHUB_ENV
+
+      - name: Download yarn.js binary
+        run: |
+          curl -L -o "$YARN_FILENAME" "https://repo.yarnpkg.com/${YARN_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
+          ls -lh "$YARN_FILENAME"
+
+      - name: Display SHA256 checksum
+        run: |
+          sha256sum "$YARN_FILENAME"
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh -y
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create the release if it doesn't exist
+          gh release view "$RELEASE_TAG" || gh release create "$RELEASE_TAG" --title "Yarn $YARN_VERSION" --notes "Yarn CLI $YARN_VERSION binary."
+
+      - name: Upload yarn.js to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$RELEASE_TAG" "$YARN_FILENAME" --clobber
+
+      - name: Output download URL
+        run: |
+          echo "Download URL: https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/${YARN_FILENAME}" 

--- a/.github/workflows/upload-yarn-binary.yml
+++ b/.github/workflows/upload-yarn-binary.yml
@@ -14,47 +14,40 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      YARN_VERSION: ${{ github.event.inputs.yarn_version }}
+      YARN_FILENAME: yarn-${{ github.event.inputs.yarn_version }}.js
+      RELEASE_TAG: v${{ github.event.inputs.yarn_version }}
+    outputs:
+      download_url: ${{ steps.output-url.outputs.download_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up variables
-        id: vars
-        run: |
-          {
-            echo "YARN_VERSION=${{ github.event.inputs.yarn_version }}"
-            echo "YARN_FILENAME=yarn-${{ github.event.inputs.yarn_version }}.js"
-            echo "RELEASE_TAG=v${{ github.event.inputs.yarn_version }}"
-          } >> "$GITHUB_ENV"
-
       - name: Download yarn.js binary
         run: |
-          curl -L -o "$YARN_FILENAME" "https://repo.yarnpkg.com/${YARN_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
-          ls -lh "$YARN_FILENAME"
+          curl -L -o "${YARN_FILENAME}" "https://repo.yarnpkg.com/${YARN_VERSION}/packages/yarnpkg-cli/bin/yarn.js"
+          ls -lh "${YARN_FILENAME}"
 
       - name: Display SHA256 checksum
         run: |
-          sha256sum "$YARN_FILENAME"
+          sha256sum "${YARN_FILENAME}"
 
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create the release if it doesn't exist
-          gh release view "$RELEASE_TAG" || gh release create "$RELEASE_TAG" --title "Yarn $YARN_VERSION" --notes "Yarn CLI $YARN_VERSION binary."
+          gh release view "${RELEASE_TAG}" || gh release create "${RELEASE_TAG}" --title "Yarn ${YARN_VERSION}" --notes "Yarn CLI ${YARN_VERSION} binary."
 
       - name: Upload yarn.js to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "$RELEASE_TAG" "$YARN_FILENAME" --clobber
+          gh release upload "${RELEASE_TAG}" "${YARN_FILENAME}" --clobber
 
       - name: Output download URL
         id: output-url
         run: |
-          url="https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/${YARN_FILENAME}"
-          echo "Download URL: $url"
-          echo "download_url=$url" >> "$GITHUB_OUTPUT"
-
-    outputs:
-      download_url: ${{ steps.output-url.outputs.download_url }}
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${YARN_FILENAME}"
+          echo "Download URL: ${url}"
+          echo "download_url=${url}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/upload-yarn-binary.yml
+++ b/.github/workflows/upload-yarn-binary.yml
@@ -47,5 +47,11 @@ jobs:
           gh release upload "$RELEASE_TAG" "$YARN_FILENAME" --clobber
 
       - name: Output download URL
+        id: output-url
         run: |
-          echo "Download URL: https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/${YARN_FILENAME}" 
+          url="https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/${YARN_FILENAME}"
+          echo "Download URL: $url"
+          echo "download_url=$url" >> "$GITHUB_OUTPUT"
+
+    outputs:
+      download_url: ${{ steps.output-url.outputs.download_url }}

--- a/.github/workflows/upload-yarn-binary.yml
+++ b/.github/workflows/upload-yarn-binary.yml
@@ -18,9 +18,11 @@ jobs:
       - name: Set up variables
         id: vars
         run: |
-          echo "YARN_VERSION=${{ github.event.inputs.yarn_version }}" >> $GITHUB_ENV
-          echo "YARN_FILENAME=yarn-${{ github.event.inputs.yarn_version }}.js" >> $GITHUB_ENV
-          echo "RELEASE_TAG=v${{ github.event.inputs.yarn_version }}" >> $GITHUB_ENV
+          {
+            echo "YARN_VERSION=${{ github.event.inputs.yarn_version }}"
+            echo "YARN_FILENAME=yarn-${{ github.event.inputs.yarn_version }}.js"
+            echo "RELEASE_TAG=v${{ github.event.inputs.yarn_version }}"
+          } >> "$GITHUB_ENV"
 
       - name: Download yarn.js binary
         run: |
@@ -30,11 +32,6 @@ jobs:
       - name: Display SHA256 checksum
         run: |
           sha256sum "$YARN_FILENAME"
-
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh -y
 
       - name: Create or update GitHub Release
         env:

--- a/.github/workflows/upload-yarn-binary.yml
+++ b/.github/workflows/upload-yarn-binary.yml
@@ -15,6 +15,9 @@ jobs:
       contents: write
       packages: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up variables
         id: vars
         run: |


### PR DESCRIPTION
**What is the current state of things and why does it need to change?**

Currently, there is no automated way to upload Yarn binaries to GitHub Releases in this repository. This is needed to provide a reliable, rate-limit-free, and cost-effective way for CI pipelines and other consumers to fetch specific Yarn versions.

**What is the solution your changes offer and how does it work?**

This PR introduces a new GitHub Actions workflow (`.github/workflows/upload-yarn-binary.yml`) that allows maintainers to manually upload a specific Yarn version (e.g., 4.9.1) as a release asset. The workflow:
- Accepts a Yarn version as input.
- Downloads the corresponding `yarn.js` binary.
- Creates or updates a GitHub Release for that version.
- Uploads the binary as a release asset.
- Outputs the download URL for use in CI or documentation.

**Are there any issues or other links reviewers should consult to understand this pull request better?**

- See: [INFRA-2575](https://consensyssoftware.atlassian.net/browse/INFRA-2575)
