### PR TITLE
fix: "Create Release Pull Request" on Extension

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -74,8 +74,12 @@ get_release_branch_name() {
         return 0
     fi
 
-    # Use consistent release branch naming for all platforms
-    echo "release/${new_version}"
+    # Different release branch naming for different platforms
+    if [[ "$platform" == "mobile" ]]; then
+      echo "release/${new_version}"
+    elif [[ "$platform" == "extension" ]]; then
+      echo "Version-v${new_version}"
+    fi
 }
 
 # Main Script


### PR DESCRIPTION
On Extension, the release branches are named `Version-vx.x.x`, not `release/x.x.x`