### PR TITLE
ci: adapt PR size job to add sizes label

### DIFF
--- a/.github/workflows/pr-line-check.yml
+++ b/.github/workflows/pr-line-check.yml
@@ -117,13 +117,13 @@ jobs:
             const total = parseInt('${{ steps.line_count.outputs.lines_changed }}') || 0;
             const additions = parseInt('${{ steps.line_count.outputs.additions }}') || 0;
             const deletions = parseInt('${{ steps.line_count.outputs.deletions }}') || 0;
-            const maxLines = parseInt('${{ inputs.max_lines }}');
 
-            // Size thresholds from inputs
-            const xsMaxSize = parseInt('${{ inputs.xs_max_size }}');
-            const sMaxSize = parseInt('${{ inputs.s_max_size }}');
-            const mMaxSize = parseInt('${{ inputs.m_max_size }}');
-            const lMaxSize = parseInt('${{ inputs.l_max_size }}');
+            // Thresholds from inputs with fallback to defaults
+            const maxLines = parseInt('${{ inputs.max_lines }}') || 1000;
+            const xsMaxSize = parseInt('${{ inputs.xs_max_size }}') || 10;
+            const sMaxSize = parseInt('${{ inputs.s_max_size }}') || 100;
+            const mMaxSize = parseInt('${{ inputs.m_max_size }}') || 500;
+            const lMaxSize = parseInt('${{ inputs.l_max_size }}') || 1000;
 
             // Print summary
             console.log('Summary:');
@@ -164,36 +164,31 @@ jobs:
               });
               
               const currentLabelNames = currentLabels.data.map(l => l.name);
-              const currentSizeLabels = currentLabelNames.filter(name => existingSizeLabels.includes(name));
               
-              // Check if we already have the correct label
-              if (currentSizeLabels.length === 1 && currentSizeLabels[0] === sizeLabel) {
+              // Build new label set: keep non-size labels and add the new size label
+              const newLabels = currentLabelNames
+                .filter(name => !existingSizeLabels.includes(name))  // Remove all size labels
+                .concat(sizeLabel);  // Add the correct size label
+              
+              // Check if labels need updating
+              const currentSizeLabel = currentLabelNames.find(name => existingSizeLabels.includes(name));
+              if (currentSizeLabel === sizeLabel && currentLabelNames.length === newLabels.length) {
                 console.log(`✅ Correct label '${sizeLabel}' already present, no changes needed`);
               } else {
-                // Remove only the size labels that need to be removed
-                for (const label of currentSizeLabels) {
-                  if (label !== sizeLabel) {
-                    await github.rest.issues.removeLabel({
-                      owner,
-                      repo,
-                      issue_number,
-                      name: label
-                    });
-                    console.log(`  - Removed label: ${label}`);
-                  }
-                }
+                // Update all labels in a single API call
+                await github.rest.issues.setLabels({
+                  owner,
+                  repo,
+                  issue_number,
+                  labels: newLabels
+                });
                 
-                // Add the new label only if it's not already present
-                if (!currentLabelNames.includes(sizeLabel)) {
-                  await github.rest.issues.addLabels({
-                    owner,
-                    repo,
-                    issue_number,
-                    labels: [sizeLabel]
-                  });
+                if (currentSizeLabel && currentSizeLabel !== sizeLabel) {
+                  console.log(`  - Replaced '${currentSizeLabel}' with '${sizeLabel}'`);
+                } else if (!currentSizeLabel) {
                   console.log(`✅ Added '${sizeLabel}' label to PR #${issue_number}`);
                 } else {
-                  console.log(`✅ Label '${sizeLabel}' already present`);
+                  console.log(`✅ Updated labels for PR #${issue_number}`);
                 }
               }
             } catch (error) {

--- a/.github/workflows/pr-line-check.yml
+++ b/.github/workflows/pr-line-check.yml
@@ -99,8 +99,8 @@ jobs:
 
           # Calculate additions and deletions across all changes between the base and HEAD,
           # filtering out files matching the ignore pattern.
-          additions=$(git diff "origin/$BASE_BRANCH"...HEAD --numstat | grep -Ev "$ignore_pattern" | awk '{add += $1} END {print add}')
-          deletions=$(git diff "origin/$BASE_BRANCH"...HEAD --numstat | grep -Ev "$ignore_pattern" | awk '{del += $2} END {print del}')
+          additions=$(git diff "origin/$BASE_BRANCH"...HEAD --numstat | grep -Ev "$ignore_pattern" | awk '{add += $1} END {print add+0}')
+          deletions=$(git diff "origin/$BASE_BRANCH"...HEAD --numstat | grep -Ev "$ignore_pattern" | awk '{del += $2} END {print del+0}')
           total=$((additions + deletions))
 
           echo "Additions: $additions, Deletions: $deletions, Total: $total"
@@ -112,9 +112,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const total = parseInt('${{ steps.line_count.outputs.lines_changed }}');
-            const additions = parseInt('${{ steps.line_count.outputs.additions }}');
-            const deletions = parseInt('${{ steps.line_count.outputs.deletions }}');
+            const total = parseInt('${{ steps.line_count.outputs.lines_changed }}') || 0;
+            const additions = parseInt('${{ steps.line_count.outputs.additions }}') || 0;
+            const deletions = parseInt('${{ steps.line_count.outputs.deletions }}') || 0;
             const maxLines = parseInt('${{ inputs.max_lines }}');
 
             // Size thresholds from inputs

--- a/.github/workflows/pr-line-check.yml
+++ b/.github/workflows/pr-line-check.yml
@@ -18,6 +18,26 @@ on:
         required: false
         type: string
         default: '(\.lock$)'
+      xs_max_size:
+        description: 'Maximum lines for XS size'
+        required: false
+        type: number
+        default: 10
+      s_max_size:
+        description: 'Maximum lines for S size'
+        required: false
+        type: number
+        default: 100
+      m_max_size:
+        description: 'Maximum lines for M size'
+        required: false
+        type: number
+        default: 500
+      l_max_size:
+        description: 'Maximum lines for L size'
+        required: false
+        type: number
+        default: 1000
 
 jobs:
   check-lines:
@@ -85,9 +105,103 @@ jobs:
 
           echo "Additions: $additions, Deletions: $deletions, Total: $total"
           echo "lines_changed=$total" >> "$GITHUB_OUTPUT"
+          echo "additions=$additions" >> "$GITHUB_OUTPUT"
+          echo "deletions=$deletions" >> "$GITHUB_OUTPUT"
 
-          max_lines="${{ inputs.max_lines }}"
-          if [ "$total" -gt "$max_lines" ]; then
-            echo "Error: Total changed lines ($total) exceed the limit of $max_lines."
-            exit 1
-          fi
+      - name: Check line count limit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const total = parseInt('${{ steps.line_count.outputs.lines_changed }}');
+            const additions = parseInt('${{ steps.line_count.outputs.additions }}');
+            const deletions = parseInt('${{ steps.line_count.outputs.deletions }}');
+            const maxLines = parseInt('${{ inputs.max_lines }}');
+
+            // Size thresholds from inputs
+            const xsMaxSize = parseInt('${{ inputs.xs_max_size }}');
+            const sMaxSize = parseInt('${{ inputs.s_max_size }}');
+            const mMaxSize = parseInt('${{ inputs.m_max_size }}');
+            const lMaxSize = parseInt('${{ inputs.l_max_size }}');
+
+            // Print summary
+            console.log('Summary:');
+            console.log(`  - Additions: ${additions}`);
+            console.log(`  - Deletions: ${deletions}`);
+            console.log(`  - Total: ${total}`);
+            console.log(`  - Limit: ${maxLines}`);
+
+            // Determine size label based on configured criteria
+            let sizeLabel = '';
+            if (total <= xsMaxSize) {
+              sizeLabel = 'size-XS';
+            } else if (total <= sMaxSize) {
+              sizeLabel = 'size-S';
+            } else if (total <= mMaxSize) {
+              sizeLabel = 'size-M';
+            } else if (total <= lMaxSize) {
+              sizeLabel = 'size-L';
+            } else {
+              sizeLabel = 'size-XL';
+            }
+
+            console.log(`  - Size category: ${sizeLabel}`);
+
+            // Manage PR labels
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            try {
+              const existingSizeLabels = ['size-XS', 'size-S', 'size-M', 'size-L', 'size-XL'];
+              
+              // Get current labels
+              const currentLabels = await github.rest.issues.listLabelsOnIssue({
+                owner,
+                repo,
+                issue_number
+              });
+              
+              const currentLabelNames = currentLabels.data.map(l => l.name);
+              const currentSizeLabels = currentLabelNames.filter(name => existingSizeLabels.includes(name));
+              
+              // Check if we already have the correct label
+              if (currentSizeLabels.length === 1 && currentSizeLabels[0] === sizeLabel) {
+                console.log(`✅ Correct label '${sizeLabel}' already present, no changes needed`);
+              } else {
+                // Remove only the size labels that need to be removed
+                for (const label of currentSizeLabels) {
+                  if (label !== sizeLabel) {
+                    await github.rest.issues.removeLabel({
+                      owner,
+                      repo,
+                      issue_number,
+                      name: label
+                    });
+                    console.log(`  - Removed label: ${label}`);
+                  }
+                }
+                
+                // Add the new label only if it's not already present
+                if (!currentLabelNames.includes(sizeLabel)) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number,
+                    labels: [sizeLabel]
+                  });
+                  console.log(`✅ Added '${sizeLabel}' label to PR #${issue_number}`);
+                } else {
+                  console.log(`✅ Label '${sizeLabel}' already present`);
+                }
+              }
+            } catch (error) {
+              console.log(`⚠️  Could not manage labels: ${error.message}`);
+            }
+
+            // Check if exceeds limit
+            if (total > maxLines) {
+              console.log(`❌ Error: Total changed lines (${total}) exceed the limit of ${maxLines}.`);
+              process.exit(1);
+            } else {
+              console.log(`✅ Success: Total changed lines (${total}) are within the limit of ${maxLines}.`);
+            }

--- a/.github/workflows/pr-line-check.yml
+++ b/.github/workflows/pr-line-check.yml
@@ -104,9 +104,11 @@ jobs:
           total=$((additions + deletions))
 
           echo "Additions: $additions, Deletions: $deletions, Total: $total"
-          echo "lines_changed=$total" >> "$GITHUB_OUTPUT"
-          echo "additions=$additions" >> "$GITHUB_OUTPUT"
-          echo "deletions=$deletions" >> "$GITHUB_OUTPUT"
+          {
+            echo "lines_changed=$total"
+            echo "additions=$additions"
+            echo "deletions=$deletions"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check line count limit
         uses: actions/github-script@v7


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Adapt `PR size job` to add sizes label:

```
default values
size-XS: ≤ 10 lines
size-S: ≤ 100 lines
size-M: ≤ 500 lines
size-L: ≤ 1000 lines
size-XL: > 1000 lines
```

Also adapt the calculation of changes by adding +0 in the awk END block to ensure that when there are no changes, awk outputs 0 instead of an empty string:

```
{print add} → {print add+0}
{print del} → {print del+0}
```


tested here: https://github.com/MetaMask/metamask-mobile/actions/runs/16826192546/job/47663091866