### PR TITLE
fix(changelog-check): improve devDependencies section detection in git diffs

### DIFF
--- a/src/changelog-check.ts
+++ b/src/changelog-check.ts
@@ -140,7 +140,10 @@ const getDevDependencyLines = (
     }
   }
 
-  if (devDependencySectionStart === undefined) {
+  if (
+    devDependencySectionStart === undefined ||
+    devDependencySectionEnd === undefined
+  ) {
     return [];
   }
 
@@ -148,12 +151,10 @@ const getDevDependencyLines = (
   for (const changeLine of nonVersionLines) {
     const lineIndex = allLines.findIndex((line) => line === changeLine);
     if (lineIndex !== -1) {
-      // Check if this line falls within the devDependencies section
-      // If we don't have an end, assume everything after start is in devDependencies
+      // Check if this line falls within any devDependencies section
       const isInDevDeps =
         lineIndex >= devDependencySectionStart &&
-        (devDependencySectionEnd === undefined ||
-          lineIndex <= devDependencySectionEnd);
+        lineIndex <= devDependencySectionEnd;
 
       if (isInDevDeps) {
         devDependencyLines.push(changeLine);
@@ -201,7 +202,13 @@ async function analyzePackageJsonChanges(
   try {
     const { stdout } = await execa(
       'git',
-      ['diff', '-U20', `origin/${baseRef}...HEAD`, '--', filePath],
+      [
+        'diff',
+        '-U9999', // Show maximum context to ensure section headers are visible
+        `origin/${baseRef}...HEAD`,
+        '--',
+        filePath,
+      ],
       {
         cwd: repoPath,
       },


### PR DESCRIPTION
## Problem
The changelog check was failing to properly detect when package.json changes were only in `devDependencies` because the git diff logic required both the start and end of the `devDependencies` section to be visible. In many cases, especially with limited diff context (`-U20`), the closing brace of the `devDependencies` section might not be included in the diff output.

## Solution
- **Fixed section detection logic**:  Use maximum context to ensure section headers are visible (`-U9999`) instead of (`-U20`)

## Testing
This fix ensures that packages with only devDependency changes are properly skipped during changelog checks, preventing false positives that would require unnecessary changelog updates.

This should resolve the CI failure that occurred in this PR: https://github.com/MetaMask/core/pull/6331

## Impact
- ✅ Fixes false positive changelog requirements for dev-only changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase git diff context to `-U9999` so `package.json` section headers (e.g., `devDependencies`) are reliably present in diffs.
> 
> - **Changelog check** (`src/changelog-check.ts`):
>   - Use `git diff -U9999` (max context) when analyzing `package.json` changes to ensure section headers like `"devDependencies"` are visible for accurate detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39fafddb003916d0fe4dc5810c6401510cb852d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->