### PR TITLE
ci: disable google sheets updates in release PR script

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -315,11 +315,13 @@ create_changelog_pr() {
     echo "Generating test plan csv.."
     yarn run gen:commits "${platform}" "${previous_version}" "${release_branch_name}" "${PROJECT_GIT_DIR}"
 
-    if [[ "${TEST_ONLY:-false}" == 'false' ]]; then
-      echo "Updating release sheet.."
-      # Create a new Release Sheet Page for the new version with our commits.csv content
-      yarn run update-release-sheet "${platform}" "${new_version}" "${GOOGLE_DOCUMENT_ID}" "./commits.csv" "${PROJECT_GIT_DIR}" "${MOBILE_TEMPLATE_SHEET_ID}" "${EXTENSION_TEMPLATE_SHEET_ID}"
-    fi
+    # Skipping Google Sheets update since there is no need for it anymore
+    # TODO: Remove this once the current post-main validation approach is stable
+    # if [[ "${TEST_ONLY:-false}" == 'false' ]]; then
+    #   echo "Updating release sheet.."
+    #   # Create a new Release Sheet Page for the new version with our commits.csv content
+    #   yarn run update-release-sheet "${platform}" "${new_version}" "${GOOGLE_DOCUMENT_ID}" "./commits.csv" "${PROJECT_GIT_DIR}" "${MOBILE_TEMPLATE_SHEET_ID}" "${EXTENSION_TEMPLATE_SHEET_ID}"
+    # fi
     cd ../
 
     # Commit and Push Changelog Changes


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Commented out the google sheets updates from `create-platform-release-pr.sh` while preserving CSV generation. There is no need to update the google sheet anymore since we have the changes already there from main in a daily basis.
