### PR TITLE
INFRA-2867-Fix workflow inputs to allow branch name

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -306,6 +306,16 @@ create_changelog_pr() {
     # Need to run from .github-tools context to inherit it's dependencies/environment
     echo "Current Directory: $(pwd)"
     PROJECT_GIT_DIR=$(pwd)
+
+    # Resolve previous_version when it's a branch name: fetch and use origin/<branch>
+    DIFF_BASE="${previous_version}"
+    if git ls-remote --heads origin "${previous_version}" | grep -qE "\srefs/heads/${previous_version}$"; then
+      echo "Detected remote branch for previous version: ${previous_version}"
+      git fetch origin "${previous_version}"
+      DIFF_BASE="origin/${previous_version}"
+    fi
+
+    # Switch to github-tools directory
     cd ./github-tools/
     ls -ltra
     corepack prepare yarn@4.5.1 --activate
@@ -313,8 +323,8 @@ create_changelog_pr() {
     yarn --cwd install
 
     echo "Generating test plan csv.."
-    yarn run gen:commits "${platform}" "${previous_version}" "${release_branch_name}" "${PROJECT_GIT_DIR}"
-
+    yarn run gen:commits "${platform}" "${DIFF_BASE}" "${release_branch_name}" "${PROJECT_GIT_DIR}"
+    
     # Skipping Google Sheets update since there is no need for it anymore
     # TODO: Remove this once the current post-main validation approach is stable
     # if [[ "${TEST_ONLY:-false}" == 'false' ]]; then

--- a/.github/scripts/generate-rc-commits.mjs
+++ b/.github/scripts/generate-rc-commits.mjs
@@ -59,7 +59,7 @@ async function getTeam(repository, prNumber) {
 }
 
 // Function to filter commits based on unique commit messages and group by teams
-async function filterCommitsByTeam(platform, branchA, branchB) {
+async function filterCommitsByTeam(platform, refA, refB) {
 
   const MAX_COMMITS = 500; // Limit the number of commits to process
   console.log('Filtering commits by team...');
@@ -81,8 +81,8 @@ async function filterCommitsByTeam(platform, branchA, branchB) {
     const git = simpleGit();
 
     const logOptions = {
-      from: branchB,
-      to: branchA,
+      from: refB,
+      to: refA,
       format: {
         hash: '%H',
         author: '%an',
@@ -92,7 +92,7 @@ async function filterCommitsByTeam(platform, branchA, branchB) {
 
     const log = await git.log(logOptions);
 
-    console.log(`Total commits between ${branchA} and ${branchB}: ${log.total}`);
+    console.log(`Total commits between ${refA} and ${refB}: ${log.total}`);
     console.log(`Processing up to ${Math.min(log.all.length, MAX_COMMITS)} commits...`);
 
     const commitsByTeam = {};
@@ -204,15 +204,15 @@ async function main() {
 
   if (args.length !== 4) {
     console.error(
-      'Usage: node generate-rc-commits.mjs platform branchA branchB',
+      'Usage: node generate-rc-commits.mjs platform refA refB',
     );
     console.error('Received:', args, ' with length:', args.length);
     process.exit(1);
   }
 
   const platform = args[0];
-  const branchA = args[1];
-  const branchB = args[2];
+  const refA = args[1];
+  const refB = args[2];
   const gitDir = args[3];
 
   // Change the working directory to the git repository path
@@ -220,10 +220,10 @@ async function main() {
   process.chdir(gitDir);
 
   console.log(
-    `Generating CSV file for commits between ${branchA} and ${branchB} on ${platform} platform...`,
+    `Generating CSV file for commits between ${refA} and ${refB} on ${platform} platform...`,
   );
 
-  const commitsByTeam = await filterCommitsByTeam(platform, branchA, branchB);
+  const commitsByTeam = await filterCommitsByTeam(platform, refA, refB);
 
   if (Object.keys(commitsByTeam).length === 0) {
     console.log('No commits found.');

--- a/.github/scripts/generate-rc-commits.mjs
+++ b/.github/scripts/generate-rc-commits.mjs
@@ -59,6 +59,7 @@ async function getTeam(repository, prNumber) {
 }
 
 // Function to filter commits based on unique commit messages and group by teams
+// Input parameters refA and refB can be a branch name, a tag or a commit hash (e.g., release/7.7.0, v7.7.0, or 76fbc500034db9779e9ff7ce637ac5be1da0493d)
 async function filterCommitsByTeam(platform, refA, refB) {
 
   const MAX_COMMITS = 500; // Limit the number of commits to process

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -22,7 +22,7 @@ on:
       previous-version-ref:
         required: true
         type: string
-        description: 'Previous release version tag or branch name. eg: v7.7.0'
+        description: 'Previous release version branch name, tag or commit hash (e.g., release/7.7.0, v7.7.0, or 76fbc500034db9779e9ff7ce637ac5be1da0493d)'
       # Flag to indicate if the release is a test release for development purposes only
       mobile-template-sheet-id:
         required: false

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -19,10 +19,10 @@ on:
         required: false
         type: string
         description: 'The build version for the mobile platform.'
-      previous-version-tag:
+      previous-version-ref:
         required: true
         type: string
-        description: 'Previous release version tag. eg: v7.7.0'
+        description: 'Previous release version tag or branch name. eg: v7.7.0'
       # Flag to indicate if the release is a test release for development purposes only
       mobile-template-sheet-id:
         required: false
@@ -108,7 +108,7 @@ jobs:
           echo "Checkout Base Branch: ${{ inputs.checkout-base-branch }}"
           echo "Release PR Base Branch: ${{ inputs.release-pr-base-branch }}"
           echo "Semver Version: ${{ inputs.semver-version }}"
-          echo "Previous Version Tag: ${{ inputs.previous-version-tag }}"
+          echo "Previous Version Reference: ${{ inputs.previous-version-ref }}"
           echo "Test Only Mode: ${{ inputs.test-only }}"
           if [[ "${{ inputs.platform }}" == "mobile" ]]; then
             echo "Mobile Build Version: ${{ inputs.mobile-build-version }}"
@@ -140,7 +140,7 @@ jobs:
           # Execute the script from github-tools
           ./github-tools/.github/scripts/create-platform-release-pr.sh \
             ${{ inputs.platform }} \
-            ${{ inputs.previous-version-tag }} \
+            ${{ inputs.previous-version-ref }} \
             ${{ inputs.semver-version }} \
             ${{ inputs.mobile-build-version }} \
             ${{ inputs.git-user-name }} \


### PR DESCRIPTION
Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-2867

The Github Action is supposed to accept 3 kind of references as inputs: branch name, tag, commit hash. However, it doesn’t work with branch names. To fix this, we should check the format of the references passed to [filterCommitsByTeam](https://github.com/MetaMask/github-tools/blob/dde6d530bebae07d1e50180894ab2cac64170a2c/.github/scripts/generate-rc-commits.mjs#L62) function in github-tools repo, detect if the reference is a branch name, and if so, prefix it with origin/. Otherwise the Github Action can’t find the branch. Additionally we should check if the branch exists before calling [filterCommitsByTeam](https://github.com/MetaMask/github-tools/blob/dde6d530bebae07d1e50180894ab2cac64170a2c/.github/scripts/generate-rc-commits.mjs#L62) function (or at the beginning of the function) and throw appropriate error message if it doesn’t.

This PR adds branch name as a possible input for **Previous release version reference** in **Create Release Pull Request Workflow**

Tested here: https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/17220284141/job/48854743844
