### PR TITLE
INFRA-2867: Skip version bump PR creation if already exists, commit in main

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -404,6 +404,14 @@ Platform: ${platform}"
         echo "Version bump committed"
     fi
 
+    # If the version bump branch has no commits ahead of main, skip pushing/PR creation
+    # right-only count gives number of commits unique to the version bump branch
+    ahead_count=$(git rev-list --right-only --count "${main_branch}...${version_bump_branch_name}" || echo 0)
+    if [ "${ahead_count}" -eq 0 ]; then
+        echo "No differences between ${main_branch} and ${version_bump_branch_name}; skipping version bump PR creation."
+        return 0
+    fi
+
     local version_bump_body="## Version Bump After Release
 
 This PR bumps the ${main_branch} branch version from ${new_version} to ${next_version} after cutting the release branch.


### PR DESCRIPTION
Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-2867
Skip version bump PR creation if already exists, commit in main

```
The Github Action is not idempotent. We should be able to re-launch the Github Action several times successfully.

- If the version bump PR already exists, Github Action will fail (example [here](https://github.com/MetaMask/metamask-extension/actions/runs/16743685688/job/47397153780)). It needs to be deleted first before re-running the Github Action.
```

Error reproduced [here](https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/17273008509/job/49022525460)
Fix tested here: https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/17276145574/job/49033208400
