### PR TITLE
chore(master): rename master branch into stable

### DIFF
--- a/.github/scripts/get-release-timelines.sh
+++ b/.github/scripts/get-release-timelines.sh
@@ -32,7 +32,7 @@ echo "release_pr_merged_at,release_submitted_at,rollout_1_at,rollout_10_at,rollo
 release_branch="Version-v${VERSION}"
 release_pr_title="Version v${VERSION}"
 
-release_pr=$(gh pr list --repo "${OWNER}/${REPOSITORY}" --head "${release_branch}" --base master --state merged --json title,mergedAt | jq --arg title "${release_pr_title}" '.[] | select(.title == $title)')
+release_pr=$(gh pr list --repo "${OWNER}/${REPOSITORY}" --head "${release_branch}" --base stable --state merged --json title,mergedAt | jq --arg title "${release_pr_title}" '.[] | select(.title == $title)')
 release_pr_merged_at=$(echo "${release_pr}" | jq -r '.mergedAt')
 
 if [[ -z "${release_pr_merged_at}" || "${release_pr_merged_at}" == "null" ]]; then

--- a/.github/workflows/stable-sync.yml
+++ b/.github/workflows/stable-sync.yml
@@ -18,7 +18,7 @@ on:
       stable-branch-name:
         required: false
         type: string
-        description: 'The name of the stable branch to sync to (e.g., stable, master, main)'
+        description: 'The name of the stable branch to sync to (e.g., stable, main)'
         default: 'stable'
       github-tools-version:
         required: false
@@ -39,7 +39,7 @@ on:
       stable-branch-name:
         required: false
         type: string
-        description: 'The name of the stable branch to sync to (e.g., stable, master, main)'
+        description: 'The name of the stable branch to sync to (e.g., stable, main)'
         default: 'stable'
       github-tools-version:
         required: false


### PR DESCRIPTION
The purpose of this PR is to remove all references to `master` branch right after we've renamed `master` branch into `stable` on metamask-extension repo.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
