### PR TITLE
chore(branches): rename Version-vx.y.z branches into release/x.y.z

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -82,14 +82,7 @@ get_expected_changed_files() {
 # For all platforms: release/{version}
 # If TEST_ONLY=true: release-testing/{version}
 get_release_branch_name() {
-    local platform="$1"
-    local new_version="$2"
-
-    # Validate platform
-    if [[ "$platform" != "mobile" && "$platform" != "extension" ]]; then
-        echo "Error: Unknown platform '$platform'. Must be 'mobile' or 'extension'."
-        exit 1
-    fi
+    local new_version="$1"
 
     # Use test branch if TEST_ONLY is true
     if [ "$TEST_ONLY" == "true" ]; then
@@ -97,21 +90,7 @@ get_release_branch_name() {
         return 0
     fi
 
-    # Different release branch naming for different platforms
-    if [[ "$platform" == "mobile" ]]; then
-      echo "release/${new_version}"
-    elif [[ "$platform" == "extension" ]]; then
-      local candidate_primary="Version-v${new_version}"
-      local candidate_alt="release/${new_version}"
-      # Prefer Version-v... if it exists on origin; otherwise use release/... if present; else default to Version-v...
-      if git ls-remote --heads origin "${candidate_primary}" | grep -q "."; then
-        echo "${candidate_primary}"
-      elif git ls-remote --heads origin "${candidate_alt}" | grep -q "."; then
-        echo "${candidate_alt}"
-      else
-        echo "${candidate_primary}"
-      fi
-    fi
+    echo "release/${new_version}"
 }
 
 # Calculate next version for main branch bump
@@ -512,7 +491,7 @@ main() {
 
     # Initialize branch names
     local release_branch_name changelog_branch_name version_bump_branch_name
-    release_branch_name=$(get_release_branch_name "$PLATFORM" "$NEW_VERSION")
+    release_branch_name=$(get_release_branch_name "$NEW_VERSION")
     changelog_branch_name="chore/${NEW_VERSION}-Changelog"
     version_bump_branch_name=$(get_version_bump_branch_name "$next_version")    # Execute main workflow
     configure_git

--- a/.github/scripts/tests/test-create-platform-release-pr-full.sh
+++ b/.github/scripts/tests/test-create-platform-release-pr-full.sh
@@ -118,8 +118,7 @@ fi
 echo ""
 echo "Testing branch naming (test mode):"
 export TEST_ONLY="true"
-echo "  Mobile release: $(get_release_branch_name "1.5.3")"
-echo "  Extension release: $(get_release_branch_name "1.5.3")"
+echo "  Release: $(get_release_branch_name "1.5.3")"
 echo "  Version bump: $(get_version_bump_branch_name "1.6.0")"
 
 echo ""
@@ -164,9 +163,8 @@ echo "4️⃣  TESTING DIFFERENT SCENARIOS"
 echo "================================"
 
 echo ""
-echo "Testing with different platforms:"
-echo "Mobile release branch: $(get_release_branch_name "2.0.0")"
-echo "Extension release branch: $(get_release_branch_name "2.0.0")"
+echo "Testing release branch:"
+echo "Release branch: $(get_release_branch_name "2.0.0")"
 
 echo ""
 echo "Testing production vs test mode:"

--- a/.github/scripts/tests/test-create-platform-release-pr-full.sh
+++ b/.github/scripts/tests/test-create-platform-release-pr-full.sh
@@ -118,8 +118,8 @@ fi
 echo ""
 echo "Testing branch naming (test mode):"
 export TEST_ONLY="true"
-echo "  Mobile release: $(get_release_branch_name "mobile" "1.5.3")"
-echo "  Extension release: $(get_release_branch_name "extension" "1.5.3")"
+echo "  Mobile release: $(get_release_branch_name "1.5.3")"
+echo "  Extension release: $(get_release_branch_name "1.5.3")"
 echo "  Version bump: $(get_version_bump_branch_name "1.6.0")"
 
 echo ""
@@ -165,8 +165,8 @@ echo "================================"
 
 echo ""
 echo "Testing with different platforms:"
-echo "Mobile release branch: $(get_release_branch_name "mobile" "2.0.0")"
-echo "Extension release branch: $(get_release_branch_name "extension" "2.0.0")"
+echo "Mobile release branch: $(get_release_branch_name "2.0.0")"
+echo "Extension release branch: $(get_release_branch_name "2.0.0")"
 
 echo ""
 echo "Testing production vs test mode:"

--- a/.github/scripts/tests/test-create-platform-release-pr-functions.sh
+++ b/.github/scripts/tests/test-create-platform-release-pr-functions.sh
@@ -42,12 +42,10 @@ echo ""
 # Test get_release_branch_name function (safe - no external calls)
 echo "Testing get_release_branch_name (SAFE):"
 export TEST_ONLY="false"
-echo "  Mobile (prod): $(get_release_branch_name "1.5.3")"
-echo "  Extension (prod): $(get_release_branch_name "1.5.3")"
+echo "  Input (prod): 1.5.3 -> Output: $(get_release_branch_name "1.5.3")"
 
 export TEST_ONLY="true"
-echo "  Mobile (test): $(get_release_branch_name "1.5.3")"
-echo "  Extension (test): $(get_release_branch_name "1.5.3")"
+echo "  Input (test): 1.5.3 -> Output: $(get_release_branch_name "1.5.3")"
 
 echo ""
 

--- a/.github/scripts/tests/test-create-platform-release-pr-functions.sh
+++ b/.github/scripts/tests/test-create-platform-release-pr-functions.sh
@@ -42,12 +42,12 @@ echo ""
 # Test get_release_branch_name function (safe - no external calls)
 echo "Testing get_release_branch_name (SAFE):"
 export TEST_ONLY="false"
-echo "  Mobile (prod): $(get_release_branch_name "mobile" "1.5.3")"
-echo "  Extension (prod): $(get_release_branch_name "extension" "1.5.3")"
+echo "  Mobile (prod): $(get_release_branch_name "1.5.3")"
+echo "  Extension (prod): $(get_release_branch_name "1.5.3")"
 
 export TEST_ONLY="true"
-echo "  Mobile (test): $(get_release_branch_name "mobile" "1.5.3")"
-echo "  Extension (test): $(get_release_branch_name "extension" "1.5.3")"
+echo "  Mobile (test): $(get_release_branch_name "1.5.3")"
+echo "  Extension (test): $(get_release_branch_name "1.5.3")"
 
 echo ""
 


### PR DESCRIPTION
The purpose of this PR is to rename release branches from `Version-vx.y.z` format into `release/x.y.z`, in order to align with metamtask-mobile repo format.