### PR TITLE
fix(sign off list): remove legacy list of teams

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -260,22 +260,21 @@ create_release_pr() {
         fi
     fi
 
+    local platform_team_name
+    if [ "$platform" = "extension" ]; then
+        platform_team_name="Extension Platform"
+    elif [ "$platform" = "mobile" ]; then
+        platform_team_name="Mobile Platform"
+    else
+        echo "Error: Unknown platform '$platform'. Must be 'extension' or 'mobile'."
+        exit 1
+    fi
+
     # Prepare release PR body with team sign-off checklist
     local release_body="This is the release candidate for version ${new_version}. The changelog will be found in another PR ${changelog_branch_name}.
 
   # Team sign-off checklist
-  - [ ] team-accounts
-  - [ ] team-assets
-  - [ ] team-confirmations
-  - [ ] team-design-system
-  - [ ] team-notifications
-  - [ ] team-platform
-  - [ ] team-security
-  - [ ] team-snaps-platform
-  - [ ] team-sdk
-  - [ ] team-stake
-  - [ ] team-tiger
-  - [ ] team-wallet-framework
+  - [ ] ${platform_team_name}
 
   # Reference
   - Testing plan sheet - https://docs.google.com/spreadsheets/d/1tsoodlAlyvEUpkkcNcbZ4PM9HuC9cEM80RZeoVv5OCQ/edit?gid=404070372#gid=404070372"


### PR DESCRIPTION
The list of sign off teams posted on the release PR was legacy and is now removed.

Instead we now initialize the list with the appropriate platform teams and the list will be completed dynamically by [another automation](https://github.com/MetaMask/metamask-zaps/pull/86), based on the [content of the release](https://docs.google.com/spreadsheets/d/1tsoodlAlyvEUpkkcNcbZ4PM9HuC9cEM80RZeoVv5OCQ/edit?gid=976491905#gid=976491905).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the legacy team checklist in release PRs with a platform-specific sign-off item and adds platform validation.
> 
> - **Scripts**
>   - **`.github/scripts/create-platform-release-pr.sh`**:
>     - Replace legacy multi-team sign-off checklist in `release_body` with a single platform-specific item using `platform_team_name`.
>     - Add `platform_team_name` mapping for `extension` (Extension Platform) and `mobile` (Mobile Platform).
>     - Validate `platform` value and exit with error for unknown platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ddb4e4e145ae87c26acf3c695448411c8d5aeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->