### PR TITLE
fix: Bump Xcode 16.2 to 16.3 to fix swift module compilation issue

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: '3.1'
   xcode-version:
-    description: Xcode version to select (e.g., 16.2)
+    description: Xcode version to select (e.g., 16.3)
     required: false
-    default: '16.2'
+    default: '16.3'
   jdk-version:
     description: JDK version to use (only for Android)
     required: false


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Upgrade to use Xcode 16.3 to fix a swift modules compilation issue as described here - https://github.com/mrousavy/nitro/issues/422#issuecomment-2682880817. We encountered the problem when introducing NitroModules on the mobile client app.

Here's a successful run using the latest commit that bumps Xcode 16.3 - https://github.com/MetaMask/metamask-mobile/actions/runs/18233074525/job/51920895988?pr=20778

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `.github/actions/setup-e2e-env/action.yml` to use Xcode 16.3 (default and example) for iOS E2E setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f4144dbb1d51e4e71434b84bc47b98ba1923346. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->