### PR TITLE
INFRA-2999-Fix changelog error on mobile

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -296,8 +296,13 @@ create_changelog_pr() {
     checkout_or_create_branch "${changelog_branch_name}"
 
     # Generate Changelog and Test Plan
-    echo "Generating changelog via auto-changelog.."
-    yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize --useChangelogEntry --useShortPrLink
+    if [ "$platform" = "extension" ]; then
+        echo "Generating changelog for extension via yarn auto-changelog.."
+        yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize --useChangelogEntry --useShortPrLink
+    else
+        echo "Generating changelog for mobile via npx @metamask/auto-changelog@4.1.0.."
+        npx @metamask/auto-changelog@4.1.0 update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize
+    fi
 
     # Skip commits.csv for hotfix releases (previous_version_ref is literal "null")
     # - When we create a new major/minor release, we fetch all commits included in the release, by fetching the diff between HEAD and previous version reference.


### PR DESCRIPTION
Fix test: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18324572370/job/52185785394

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release script to use npx @metamask/auto-changelog for mobile while keeping yarn auto-changelog for extension.
> 
> - **Release scripting** (`.github/scripts/create-platform-release-pr.sh`):
>   - **Changelog generation**:
>     - Mobile: use `npx @metamask/auto-changelog@4.1.0 update --rc --repo ... --currentVersion ... --autoCategorize`.
>     - Extension: continue using `yarn auto-changelog update --rc --repo ... --currentVersion ... --autoCategorize --useChangelogEntry --useShortPrLink`.
>   - Adds platform-specific log messages for changelog generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88ceacec7cbef930c5856add18c99c877d883b23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->