### PR TITLE
MCRM-8-Updated add-team-label worklow to use topology.json

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -18,8 +18,8 @@ jobs:
           GH_TOKEN: ${{ secrets.TEAM_LABEL_TOKEN }}
           USER: ${{ github.event.pull_request.user.login }}
         run: |
-          # Stream topology.json through jq, find the first team where USER matches any of the members, pm, em or tl fields, and emit its githubLabel.name value.
-          team_label=$(gh api -H 'Accept: application/vnd.github.raw' 'repos/metamask/metamask-planning/contents/topology.json' | jq -r --arg USER "$USER" '.[] | select((.members // []) | index($USER) or (.pm // empty) == $USER or (.em // empty) == $USER or (.tl // empty) == $USER) | .githubLabel.name' | head -n 1)
+          # Stream topology.json through jq, find the first team where USER appears in members, pm, em, or tl, and emit its githubLabel.name value.
+          team_label=$(gh api -H 'Accept: application/vnd.github.raw' 'repos/metamask/metamask-planning/contents/topology.json' | jq -r --arg USER "$USER" '.[] | select(any(.members[]?; . == $USER) or (.pm // empty) == $USER or (.em // empty) == $USER or (.tl // empty) == $USER) | .githubLabel.name' | head -n 1)
           if [ -z "$team_label" ]; then
             echo "::error::Team label not found for author: $USER. Please open a pull request with your GitHub handle and team label to update topology.json at https://github.com/MetaMask/MetaMask-planning/blob/main/topology.json"
             exit 1


### PR DESCRIPTION
Ticket: https://consensyssoftware.atlassian.net/browse/MCRM-8

Updated add-team-label worklow to use topology.json file instead of old teams.json file

Tested here:
https://github.com/consensys-test/metamask-extension-test-workflow2/pull/198
https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18381574172
https://github.com/consensys-test/metamask-extension-test-workflow2/pull/199
https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18386245698/job/52386381660


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the GitHub Actions workflow to fetch the PR author’s team label from topology.json (matching members/pm/em/tl) and updates the error message accordingly.
> 
> - **CI/GitHub Actions** (`.github/workflows/add-team-label.yml`):
>   - Replace `teams.json` lookup with streaming `topology.json`; use `jq` to find first team where `USER` matches `members`, `pm`, `em`, or `tl`, then extract `.githubLabel.name`.
>   - Update error message to reference `topology.json`.
>   - Label application step remains the same (`gh issue edit --add-label`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9fbd72b8f931881ab331612f3e69573874a7da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->