### PR TITLE
Infra 2576 update changelog automatically

### DIFF
--- a/.github/scripts/update-release-changelog.sh
+++ b/.github/scripts/update-release-changelog.sh
@@ -14,7 +14,7 @@
 #                             so that commits.csv generation is skipped, matching hotfix behaviour.
 #
 # Environment (optional):
-#   GH_TOKEN             - Token for GitHub CLI operations (falls back to gh auth config)
+#   GITHUB_TOKEN         - Token for GitHub CLI operations (falls back to gh auth config)
 #   GIT_AUTHOR_NAME      - Commit author name (defaults to metamaskbot)
 #   GIT_AUTHOR_EMAIL     - Commit author email (defaults to metamaskbot@users.noreply.github.com)
 #   TEST_ONLY            - When set to "true" the helper mirrors release automation test mode.
@@ -187,7 +187,7 @@ if [[ "${RELEASE_BRANCH}" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
   VERSION="${BASH_REMATCH[1]}"
 else
   echo "Release branch '${RELEASE_BRANCH}' does not match known patterns." >&2
-  exit 0
+  exit 1
 fi
 
 GITHUB_REPOSITORY_URL="${REPOSITORY_URL}"

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -66,7 +66,6 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
-          GH_TOKEN: ${{ secrets.github-token }}
           GIT_AUTHOR_NAME: metamaskbot
           GIT_AUTHOR_EMAIL: metamaskbot@users.noreply.github.com
         run: |


### PR DESCRIPTION
Tested here: https://github.com/consensys-test/metamask-extension-test-workflow2/pull/204, https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18538077577
Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-2576

Added a new workflow to update or create the changelog when release PRs are created or receive new merges.

**Update Release Changelog PR (update-release-changelog.yml)**
**When it runs:**
  Triggers on every push to release branches matching:
  Version-v* (e.g., Version-v13.3.0)
  release/[0-9]+.[0-9]+.[0-9]+ (e.g., release/999.98.0)
**What it does:**
  Calls the github-tools update-release-changelog.yml workflow
  This workflow runs the update-release-changelog.sh script
  The script uses @metamask/auto-changelog to generate/update the changelog
  
**When CHANGELOG.md Gets Created or Updated**
**Initial Creation:**
  Branch Creation: When you create a release/999.98.0 branch
  Auto Create Release PR: Triggers and calls create-release-pr.yml
  Create Release PR: Calls github-tools to create the release PR
  Changelog Creation: The github-tools script:
  Creates a changelog branch: release/999.98.0-Changelog
  Runs yarn auto-changelog update --rc --autoCategorize --useChangelogEntry --useShortPrLink
  Creates/updates CHANGELOG.md with commits since the last tag
  Creates a PR: release: release/999.98.0-Changelog
**Subsequent Updates:**
  New Commits: When you push new commits to release/999.98.0
  Update Release Changelog PR: Triggers automatically
  Changelog Update: The workflow:
  Checks out the existing release/999.98.0-Changelog branch
  Runs the auto-changelog script again
  Updates the existing CHANGELOG.md with new commits
  Commits and pushes the changes to the existing changelog PR
  The auto-changelog looks for git tags to determine the commit range
  Duplicate Filtering: It filters out commits that don't have PR numbers or are already in the changelog






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a reusable workflow and helper script to generate/update changelog branches and draft PRs for release branches using auto-changelog.
> 
> - **GitHub Actions**:
>   - **Reusable workflow** `/.github/workflows/update-release-changelog.yml`:
>     - Accepts inputs for `release-branch`, `platform`, `repository-url`, and `previous-version-ref`; requires `github-token`.
>     - Checks out caller repo and `MetaMask/github-tools`, sets up env, installs deps, and runs changelog update script with write permissions.
> - **Scripts**:
>   - Add `/.github/scripts/update-release-changelog.sh` to:
>     - Sync `release/x.y.z` branch, determine `release/<version>-Changelog` (or fallback) branch, and checkout/create it.
>     - Run auto-changelog (extension/mobile), commit updates (hotfix-aware), push branch, and create a draft PR targeting the release branch.
>     - Remove commits.csv generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1f24c818a4e19312ee54b675b58f6c13d2a6f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->