### PR TITLE
chore: avoid applesimutils warning due already installed pacakge

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -330,7 +330,13 @@ runs:
 
     - name: Install applesimutils
       if: ${{ inputs.platform == 'ios' }}
-      run: brew tap wix/brew && brew install applesimutils
+      run: |
+        if ! brew list applesimutils &>/dev/null; then
+          brew tap wix/brew
+          brew install applesimutils
+        else
+          echo "applesimutils is already installed, skipping..."
+        fi
       shell: bash
 
     - name: Check simutils


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update iOS E2E action to skip installing applesimutils if already installed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edddc536599bcbee6107909fcd897788a1a115d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->