### PR TITLE
Fix command to use newer changelog version

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -351,7 +351,7 @@ create_changelog_pr() {
         yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize --useChangelogEntry --useShortPrLink
     else
         echo "Generating changelog for mobile via yarn auto-changelog.."
-        yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize
+        npx @metamask/auto-changelog@4.1.0 update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize
     fi
 
     # Skip commits.csv for hotfix releases (previous_version_ref is literal "null")


### PR DESCRIPTION
Fix for the following error.
[error](https://github.com/MetaMask/metamask-mobile/actions/runs/18575221900/job/52958813309):

```
Checking for existing branch release/7.58.0-Changelog
Creating new branch release/7.58.0-Changelog
Switched to a new branch 'release/7.58.0-Changelog'
Branch release/7.58.0-Changelog ready
Generating changelog for mobile via npx @metamask/auto-changelog@4.1.0..
npm warn exec The following package was not found and will be installed: @metamask/auto-changelog@4.1.0
Error: Unrecognized line: '* fix: address feature flag config issue'
    at parseChangelog (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/parse-changelog.js:147:19)
    at updateChangelog (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/update-changelog.js:107:60)
    at update (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/cli.js:91:78)
    at async main (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/cli.js:368:9)
Error: Process completed with exit code 1.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the mobile changelog generation echo to reference yarn auto-changelog instead of npx.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c9c0dda8e0d5ff6e1fc9f4ba073ee587885b9e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->