### PR TITLE
chore: updated default value flaky tests json report mobile

### DIFF
--- a/.github/scripts/create-flaky-test-report.mjs
+++ b/.github/scripts/create-flaky-test-report.mjs
@@ -20,7 +20,7 @@ const env = {
   SLACK_WEBHOOK_FLAKY_TESTS: process.env.SLACK_WEBHOOK_FLAKY_TESTS || '',
   TEST_REPORT_ARTIFACTS: process.env.TEST_REPORT_ARTIFACTS
     ? process.env.TEST_REPORT_ARTIFACTS.split(',').map(name => name.trim())
-    : ['test-e2e-android-report', 'test-e2e-ios-report', 'test-e2e-chrome-report', 'test-e2e-firefox-report'],
+    : ['e2e-android-json-report', 'e2e-ios-json-report', 'test-e2e-chrome-report', 'test-e2e-firefox-report'],
 };
 
 function getDateRange() {


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `TEST_REPORT_ARTIFACTS` defaults to new mobile JSON artifact names while keeping web artifacts unchanged.
> 
> - **CI Scripts** (`.github/scripts/create-flaky-test-report.mjs`):
>   - Update default `env.TEST_REPORT_ARTIFACTS` to `['e2e-android-json-report', 'e2e-ios-json-report', 'test-e2e-chrome-report', 'test-e2e-firefox-report']` (replaces previous Android/iOS names).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 426660ebfa887b3a959017ead8b2cb210693946b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->