### PR TITLE
fix(release branch name): cleanup deprecated release branch name

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -370,10 +370,8 @@ create_changelog_pr() {
       # Otherwise, DIFF_BASE remains unchanged.
       DIFF_BASE="${previous_version_ref}"
 
-      # Only consider known release branch patterns to avoid regex pitfalls:
-      # - Extension: Version-vx.y.z
-      # - Mobile:    release/x.y.z
-      if [[ "${previous_version_ref}" =~ ^Version-v[0-9]+\.[0-9]+\.[0-9]+$ || "${previous_version_ref}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      # Only consider known release branch patterns to avoid regex pitfalls: release/x.y.z
+      if [[ "${previous_version_ref}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Previous version looks like a release branch: ${previous_version_ref}"
         # Check if the exact branch exists on origin without interpolating into a regex
         if git ls-remote --heads origin "${previous_version_ref}" | grep -q "."; then

--- a/.github/scripts/get-release-timelines.sh
+++ b/.github/scripts/get-release-timelines.sh
@@ -29,8 +29,8 @@ release_timelines_filename="release-timelines-${VERSION}.csv"
 
 echo "release_pr_merged_at,release_submitted_at,rollout_1_at,rollout_10_at,rollout_100_at,issue_created_at,last_team_assigned_at,triage_completed_at,bugfix_pr_created_at,bugfix_pr_merged_at,cherry_pick_pr_created_at,cherry_pick_pr_merged_at" > "${release_timelines_filename}"
 
-release_branch="Version-v${VERSION}"
-release_pr_title="Version v${VERSION}"
+release_branch="release/${VERSION}"
+release_pr_title="release: ${VERSION}"
 
 release_pr=$(gh pr list --repo "${OWNER}/${REPOSITORY}" --head "${release_branch}" --base stable --state merged --json title,mergedAt | jq --arg title "${release_pr_title}" '.[] | select(.title == $title)')
 release_pr_merged_at=$(echo "${release_pr}" | jq -r '.mergedAt')

--- a/.github/scripts/slack-release-testing.mjs
+++ b/.github/scripts/slack-release-testing.mjs
@@ -108,28 +108,6 @@ function parseReleaseUpdates(data) {
 }
 
 /**
- * Determines the release branch for a given platform/version
- * @param {string} platform 'mobile' or 'extension'
- * @param {string} version semantic version
- * @returns
- */
-function getReleaseBranchName(platform, version) {
-  let releaseBranchName;
-
-  if (platform === 'mobile') {
-    releaseBranchName = `release/${version}`;
-  } else if (platform === 'extension') {
-    releaseBranchName = `Version-v${version}`;
-  } else {
-    throw new Error(
-      `Unknown platform '${platform}'. Must be 'mobile' or 'extension'.`,
-    );
-  }
-
-  return releaseBranchName;
-}
-
-/**
  * Retrieves the URL of the first pull request for a given branch in a specified GitHub repository.
  *
  * @param {string} owner - The GitHub username or organization name that owns the repository.
@@ -352,9 +330,9 @@ async function publishReleaseTestingStatus(release) {
   const fmtPlatform = formatTitle(release.Platform);
   const teamResults = parseReleaseUpdates(release.testingStatus);
   const releasePrUrl = await findPullRequestUrlByBranch(
-    'MetaMask',
-    `metamask-${release.Platform}`,
-    getReleaseBranchName(release.Platform, release.SemanticVersion),
+    'MetaMask', // repo owner
+    `metamask-${release.Platform}`, // repo name
+    `release/${release.SemanticVersion}`, // release branch name
   );
   const channel = await getPublishChannelName(release);
 

--- a/.github/scripts/tests/test-create-platform-release-pr-full.sh
+++ b/.github/scripts/tests/test-create-platform-release-pr-full.sh
@@ -152,11 +152,11 @@ configure_git
 
 echo ""
 echo "Testing create_release_pr:"
-create_release_pr "extension" "1.5.3" "100" "Version-v1.5.3" "release/1.5.3-Changelog"
+create_release_pr "extension" "1.5.3" "100" "release/1.5.3" "release/1.5.3-Changelog"
 
 echo ""
 echo "Testing create_version_bump_pr:"
-create_version_bump_pr "extension" "1.5.3" "1.6.0" "version-bump-testing/1.6.0" "Version-v1.5.3" "main"
+create_version_bump_pr "extension" "1.5.3" "1.6.0" "version-bump-testing/1.6.0" "release/1.5.3" "main"
 
 echo ""
 echo "4️⃣  TESTING DIFFERENT SCENARIOS"


### PR DESCRIPTION
Since we've aligned Extension and Mobile release branch names, we no longer use the deprecated format: `Version-vx.y.z`.
The purpose of this PR is to cleanup the repo and remove all traces of the deprecated format for release branch names.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch all scripts and tests to use release/{version} branches and "release: {version}" titles, removing legacy Version-v handling.
> 
> - **Scripts**:
>   - `create-platform-release-pr.sh`: Only treats `previous_version_ref` as a branch if it matches `release/x.y.z` (drops `Version-vx.y.z`).
> - **Release timelines**:
>   - `get-release-timelines.sh`: Use `release/${VERSION}` for `--head` and expect PR title `release: ${VERSION}`.
> - **Slack release testing**:
>   - `slack-release-testing.mjs`: Remove `getReleaseBranchName`; directly query PRs for `release/${version}`.
> - **Tests**:
>   - `tests/test-create-platform-release-pr-full.sh`: Update inputs to use `release/{version}` for release and bump PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5e70910099598abec91b34fc2a98b966662b90f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->