### PR TITLE
chore: fix e2e test reports

### DIFF
--- a/.github/scripts/create-flaky-test-report.mjs
+++ b/.github/scripts/create-flaky-test-report.mjs
@@ -12,10 +12,10 @@ if (!githubToken) throw new Error('Missing GITHUB_TOKEN env var');
 const env = {
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   LOOKBACK_DAYS: parseInt(process.env.LOOKBACK_DAYS ?? '1'),
-  TEST_RESULTS_FILE_PATTERN: process.env.TEST_RESULTS_FILE_PATTERN || 'test-runs',
+  TEST_RESULTS_FILE_PATTERN: process.env.TEST_RESULTS_FILE_PATTERN || 'json-test-report',
   OWNER: process.env.OWNER || 'MetaMask',
-  REPOSITORY: process.env.REPOSITORY || 'metamask-extension',
-  WORKFLOW_ID: process.env.WORKFLOW_ID || 'main.yml',
+  REPOSITORY: process.env.REPOSITORY || 'metamask-mobile',
+  WORKFLOW_ID: process.env.WORKFLOW_ID || 'ci.yml',
   BRANCH: process.env.BRANCH || 'main',
   SLACK_WEBHOOK_FLAKY_TESTS: process.env.SLACK_WEBHOOK_FLAKY_TESTS || '',
   TEST_REPORT_ARTIFACTS: process.env.TEST_REPORT_ARTIFACTS


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches defaults to `metamask-mobile` `ci.yml` and uses `json-test-report` as the artifact file pattern.
> 
> - **CI Scripts** (`.github/scripts/create-flaky-test-report.mjs`):
>   - Default repo/workflow updated: `REPOSITORY` -> `metamask-mobile`, `WORKFLOW_ID` -> `ci.yml`.
>   - Test artifact parsing default changed: `TEST_RESULTS_FILE_PATTERN` -> `json-test-report`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d45c6ba813a599823a77c2de6caa5bb877f773d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->