### PR TITLE
Chore flaky tests fix

### DIFF
--- a/.github/scripts/create-flaky-test-report.mjs
+++ b/.github/scripts/create-flaky-test-report.mjs
@@ -12,7 +12,7 @@ if (!githubToken) throw new Error('Missing GITHUB_TOKEN env var');
 const env = {
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   LOOKBACK_DAYS: parseInt(process.env.LOOKBACK_DAYS ?? '1'),
-  TEST_RESULTS_FILE_PATTERN: process.env.TEST_RESULTS_FILE_PATTERN || 'json-test-report',
+  TEST_RESULTS_FILE_PATTERN: process.env.TEST_RESULTS_FILE_PATTERN || 'test-runs',
   OWNER: process.env.OWNER || 'MetaMask',
   REPOSITORY: process.env.REPOSITORY || 'metamask-mobile',
   WORKFLOW_ID: process.env.WORKFLOW_ID || 'ci.yml',
@@ -20,7 +20,7 @@ const env = {
   SLACK_WEBHOOK_FLAKY_TESTS: process.env.SLACK_WEBHOOK_FLAKY_TESTS || '',
   TEST_REPORT_ARTIFACTS: process.env.TEST_REPORT_ARTIFACTS
     ? process.env.TEST_REPORT_ARTIFACTS.split(',').map(name => name.trim())
-    : ['e2e-android-json-report', 'e2e-ios-json-report', 'test-e2e-chrome-report', 'test-e2e-firefox-report'],
+    : ['test-e2e-android-json-report', 'test-e2e-ios-json-report', 'test-e2e-chrome-report', 'test-e2e-firefox-report'],
 };
 
 function getDateRange() {


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates flaky-test report script defaults to use `metamask-mobile`’s `ci.yml` workflow and new test artifact names.
> 
> - **Scripts/CI**:
>   - Update `.github/scripts/create-flaky-test-report.mjs` defaults:
>     - `REPOSITORY`: `metamask-extension` → `metamask-mobile`
>     - `WORKFLOW_ID`: `main.yml` → `ci.yml`
>     - `TEST_REPORT_ARTIFACTS`: replace `e2e-android-json-report`/`e2e-ios-json-report` with `test-e2e-android-json-report`/`test-e2e-ios-json-report`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a36f7df5020cde9dec0f4fb33535a56455e491b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->