### PR TITLE
chore: rename default E2E json report

### DIFF
--- a/.github/scripts/create-flaky-test-report.mjs
+++ b/.github/scripts/create-flaky-test-report.mjs
@@ -12,7 +12,7 @@ if (!githubToken) throw new Error('Missing GITHUB_TOKEN env var');
 const env = {
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   LOOKBACK_DAYS: parseInt(process.env.LOOKBACK_DAYS ?? '1'),
-  TEST_RESULTS_FILE_PATTERN: process.env.TEST_RESULTS_FILE_PATTERN || 'json-test-report',
+  TEST_RESULTS_FILE_PATTERN: process.env.TEST_RESULTS_FILE_PATTERN || 'test-runs',
   OWNER: process.env.OWNER || 'MetaMask',
   REPOSITORY: process.env.REPOSITORY || 'metamask-mobile',
   WORKFLOW_ID: process.env.WORKFLOW_ID || 'ci.yml',


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the flaky-test report script to default to `test-runs` artifact prefix instead of `json-test-report`.
> 
> - **CI Script**:
>   - Update default `TEST_RESULTS_FILE_PATTERN` in `.github/scripts/create-flaky-test-report.mjs` from `json-test-report` to `test-runs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be66b353bd680a4c399ec828391876f94028dfc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->