### PR TITLE
vagrant user

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -28,7 +28,7 @@ inputs:
   ruby-version:
     description: Ruby version to use (only for iOS)
     required: false
-    default: '3.1'
+    default: '3.2'
   xcode-version:
     description: Xcode version to select (e.g., 16.3)
     required: false
@@ -264,27 +264,48 @@ runs:
           
           # Map requested version to available version on Bitrise stack
           REQUESTED_VERSION="${{ inputs.ruby-version }}"
-          if [ "$REQUESTED_VERSION" = "3.1" ]; then
-            # Use the available 3.1.7 version
-            RUBY_VERSION="3.1.7"
-            echo "Using available Ruby 3.1.7"
-          elif [ "$REQUESTED_VERSION" = "3.2" ]; then
-            RUBY_VERSION="3.2.9"
-            echo "Using available Ruby 3.2.9"
-          elif [ "$REQUESTED_VERSION" = "3.3" ]; then
-            RUBY_VERSION="3.3.9"
-            echo "Using available Ruby 3.3.9"
-          elif [ "$REQUESTED_VERSION" = "3.4" ]; then
-            RUBY_VERSION="3.4.5"
-            echo "Using available Ruby 3.4.5"
-          else
-            RUBY_VERSION="$REQUESTED_VERSION"
+          
+          # Check if .ruby-version file exists and has a full version
+          if [ -f ".ruby-version" ]; then
+            EXISTING_VERSION=$(cat .ruby-version | tr -d '\n' | tr -d ' ')
+            echo "Found .ruby-version file with version: $EXISTING_VERSION"
+            
+            # Check if the version from .ruby-version is available
+            if rbenv versions --bare | grep -q "^${EXISTING_VERSION}$"; then
+              RUBY_VERSION="$EXISTING_VERSION"
+              echo "Using Ruby version from .ruby-version: $RUBY_VERSION"
+            else
+              echo "Ruby $EXISTING_VERSION from .ruby-version is not installed"
+              echo "Available versions:"
+              rbenv versions
+              # Fall back to mapping logic below
+            fi
+          fi
+          
+          # If RUBY_VERSION not set, map requested version to available
+          if [ -z "$RUBY_VERSION" ]; then
+            if [ "$REQUESTED_VERSION" = "3.1" ]; then
+              RUBY_VERSION="3.2.9"
+              echo "Mapping 3.1 -> 3.2.9 (3.1.x not available)"
+            elif [ "$REQUESTED_VERSION" = "3.2" ]; then
+              RUBY_VERSION="3.2.9"
+              echo "Using available Ruby 3.2.9"
+            elif [ "$REQUESTED_VERSION" = "3.3" ]; then
+              RUBY_VERSION="3.3.9"
+              echo "Using available Ruby 3.3.9"
+            elif [ "$REQUESTED_VERSION" = "3.4" ]; then
+              RUBY_VERSION="3.4.5"
+              echo "Using available Ruby 3.4.5"
+            else
+              RUBY_VERSION="$REQUESTED_VERSION"
+            fi
           fi
           
           echo "Setting Ruby version to: $RUBY_VERSION"
-          # Remove any local .ruby-version file that might conflict
+          
+          # Update .ruby-version file to ensure consistency
           if [ -f ".ruby-version" ]; then
-            echo "Found .ruby-version file, backing it up and updating it"
+            echo "Backing up and updating .ruby-version file"
             cp .ruby-version .ruby-version.backup
             echo "$RUBY_VERSION" > .ruby-version
           fi


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps E2E setup action to use Bitrise vagrant paths, system Ruby with rbenv mapping (default Ruby 3.2), dynamic Xcode selection, and adjusted Android/Foundry/CocoaPods paths and checks.
> 
> - **CI / E2E Action (`.github/actions/setup-e2e-env/action.yml`)**:
>   - **Runner environment**: Add step to set Bitrise vagrant user paths (`USER_HOME`, `HOME`, toolcache, temp) and create directories.
>   - **Android**: Use `USER_HOME` for `ANDROID_AVD_HOME`; no other flow changes.
>   - **Foundry**: Install paths switched to use `USER_HOME` in `FOUNDRY_DIR`.
>   - **iOS / Ruby**:
>     - Default `ruby-version` input bumped to `3.2`.
>     - Replace `ruby/setup-ruby` action with system Ruby + `rbenv`-based version mapping; install `bundler` explicitly.
>     - Enhance CocoaPods checks (add binstub path, verify via `bundle exec pod` and `pod`).
>     - Xcode selection made resilient by auto-detecting installed versions before `xcode-select`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f960df7be2137d27b372553616b7b8862f7fa41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->