### PR TITLE
test: uses foundry-version input

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -233,7 +233,7 @@ runs:
 
         echo "$FOUNDRY_BIN" >> "$GITHUB_PATH"
 
-        "$FOUNDRY_BIN/foundryup" -i '${{ inputs.foundry-version }}'
+        "$FOUNDRY_BIN/foundryup" -i "${{ inputs.foundry-version }}"
 
     ## IOS Setup ##
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
This PR makes foundry set the tool version to the one specified via input.
Currently the input is not being used causing the mobile E2E to be running on the old version.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the setup-e2e-env action install the specified Foundry version via input and set its default to v0.3.0.
> 
> - **CI/GitHub Action (`.github/actions/setup-e2e-env/action.yml`)**:
>   - Use the `foundry-version` input when installing Foundry by passing `-i` to `foundryup`.
>   - Update default `foundry-version` from `v1.2.3` to `v0.3.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5322ef0e20c37aa2efeac9d177418f24db2b8e03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->