### PR TITLE
chore: sync extension+mobile changelog processes

### DIFF
--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -346,15 +346,9 @@ create_changelog_pr() {
     checkout_or_create_branch "${changelog_branch_name}"
 
     # Generate Changelog and Test Plan
-    # Extension includes --useChangelogEntry flag which fetches PR labels from GitHub
-    # Mobile excludes --useChangelogEntry to avoid 404s when testing in fork repos ( can  be safely added after a few working releases)
-    if [ "$platform" = "extension" ]; then
-        echo "Generating changelog for extension.."
-        yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize --useChangelogEntry --useShortPrLink
-    else
-        echo "Generating changelog for mobile.."
-        yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize --useShortPrLink
-    fi
+    echo "Generating changelog for ${platform}.."
+    yarn auto-changelog update --rc --repo "${GITHUB_REPOSITORY_URL}" --currentVersion "${new_version}" --autoCategorize --useChangelogEntry --useShortPrLink
+
 
     # Skip commits.csv for hotfix releases (previous_version_ref is literal "null")
     # - When we create a new major/minor release, we fetch all commits included in the release, by fetching the diff between HEAD and previous version reference.

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -79,4 +79,3 @@ jobs:
             "${{ inputs.platform }}" \
             "${{ inputs.repository-url }}" \
             "${{ inputs.previous-version-ref }}"
-


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies changelog generation for both platforms using yarn auto-changelog with consistent flags; minor workflow cleanup.
> 
> - **Scripts**:
>   - Standardize changelog generation in `./.github/scripts/create-platform-release-pr.sh` by replacing platform-specific logic with a single `yarn auto-changelog update` call for both `extension` and `mobile`, adding `--useChangelogEntry` and `--useShortPrLink` flags.
> - **CI/Workflow**:
>   - Minor cleanup in `./.github/workflows/update-release-changelog.yml` (no functional change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673e809508bd24dc7c50d972f34031ef52ab8034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





https://consensyssoftware.atlassian.net/jira/software/c/projects/INFRA/boards/528?selectedIssue=INFRA-3013 