### PR TITLE
test: multi label + update title

### DIFF
--- a/.github/workflows/create-pr-feature-flag-registry-drift.yml
+++ b/.github/workflows/create-pr-feature-flag-registry-drift.yml
@@ -23,7 +23,12 @@ on:
         required: false
         type: string
         default: ''
-        description: 'Label to apply to the created PR (must exist in the target repo)'
+        description: 'Label(s) to apply to the created PR (comma or newline-separated; must exist in the target repo)'
+      pr-title-prefix:
+        required: false
+        type: string
+        default: 'test: Sync Feature Flag Registry'
+        description: 'Title prefix for the PR (timestamp will be appended automatically)'
       workflow-run-url:
         required: false
         type: string
@@ -135,6 +140,7 @@ jobs:
           BRANCH: ${{ steps.commit.outputs.branch }}
           TIMESTAMP: ${{ steps.commit.outputs.timestamp }}
           PR_LABEL: ${{ inputs.pr-label }}
+          PR_TITLE_PREFIX: ${{ inputs.pr-title-prefix }}
         run: |
           # Close stale open PRs on qa/sync-ff-registry-* branches (not title search, to avoid closing unrelated PRs)
           gh pr list --state open --json number,headRefName 2>/dev/null | jq -r --arg head "$BRANCH" \
@@ -147,10 +153,13 @@ jobs:
           done
           LABEL_ARGS=()
           if [[ -n "$PR_LABEL" ]]; then
-            LABEL_ARGS=(--label "$PR_LABEL")
+            while IFS= read -r label; do
+              label=$(echo "$label" | xargs)
+              [[ -n "$label" ]] && LABEL_ARGS+=(--label "$label")
+            done < <(echo "$PR_LABEL" | tr ',' '\n')
           fi
           PR_URL=$(gh pr create \
-            --title "[QA] Sync Feature Flag Registry - $TIMESTAMP" \
+            --title "${PR_TITLE_PREFIX} - $TIMESTAMP" \
             --body-file pr-body.md \
             --base main \
             --head "$BRANCH" \


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Summary

Extends the reusable **create-pr-feature-flag-registry-drift** workflow so callers can pass **multiple PR labels** (comma- or newline-separated) and a **custom PR title prefix**, while still appending the existing UTC **timestamp** suffix.

## Changes

- **`pr-label`**: Description updated; labels are split on commas/newlines, trimmed, and passed as repeated `gh pr create --label` arguments.
- **`pr-title-prefix`**: New optional `workflow_call` input (default in this commit: `test: Sync Feature Flag Registry`) wired into `PR_TITLE_PREFIX` and used as `--title "${PR_TITLE_PREFIX} - $TIMESTAMP"`.

## Testing

- [ ] Call the workflow with `pr-label` as comma-separated and multiline values and confirm all labels apply.
- [ ] Call with `pr-title-prefix` and confirm title is `{prefix} - {timestamp}`.

## Fixes

Fixes: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to a GitHub Actions workflow and only changes PR metadata (labels/title); main risk is minor label parsing issues affecting labeling.
> 
> **Overview**
> Updates the reusable `create-pr-feature-flag-registry-drift` workflow to support applying **multiple PR labels** by parsing `pr-label` as comma/newline-separated values and passing repeated `gh pr create --label` flags.
> 
> Adds a new optional `pr-title-prefix` input and uses it to build the PR title (`${prefix} - ${timestamp}`) instead of the previously hardcoded `[QA] Sync Feature Flag Registry` title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75d3d57a43de0b365e48957491ba85d10f86c236. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->