### PR TITLE
chore: use single header row for post merge spreadsheet

### DIFF
--- a/.github/scripts/post-merge-validation-tracker.mjs
+++ b/.github/scripts/post-merge-validation-tracker.mjs
@@ -76,8 +76,8 @@ function headerRowFor(type) {
 
 function platformLabelFor(type) {
   const t = String(type).toLowerCase();
-  if (t === 'mobile') return '📱 Mobile';
-  if (t === 'extension') return '🔌 Extension';
+  if (t === 'mobile') return '📱 Mobile - Pull requests';
+  if (t === 'extension') return '🔌 Extension - Pull requests';
   return t;
 }
 
@@ -129,7 +129,7 @@ async function createSheetFromTemplateOrBlank(authClient, sheetsList, title, pla
       },
     });
     const newSheetId = duplicateRes.data.replies?.[0]?.duplicateSheet?.properties?.sheetId;
-    // Write platform label in A1 and platform-specific labels; keep row 2 headers from template to preserve formatting
+    // Write platform label in A1
     await sheets.spreadsheets.values.update({
       spreadsheetId,
       auth: authClient,
@@ -137,15 +137,7 @@ async function createSheetFromTemplateOrBlank(authClient, sheetsList, title, pla
       valueInputOption: 'USER_ENTERED',
       requestBody: { values: [[platformLabelFor(platformType)]] },
     });
-    // Overwrite entire row 2 with headerRowFor(type)
-    await sheets.spreadsheets.values.update({
-      spreadsheetId,
-      auth: authClient,
-      range: `${title}!A2:H2`,
-      valueInputOption: 'USER_ENTERED',
-      requestBody: { values: [headerRowFor(platformType)] },
-    });
-    // Insert a blank row at index 2 (0-based) so data can start at row 4
+    // Insert a blank row at index 1 (0-based) so data can start at row 3
     await sheets.spreadsheets.batchUpdate({
       spreadsheetId,
       auth: authClient,
@@ -159,7 +151,7 @@ async function createSheetFromTemplateOrBlank(authClient, sheetsList, title, pla
           },
           {
             insertDimension: {
-              range: { sheetId: newSheetId, dimension: 'ROWS', startIndex: 2, endIndex: 3 },
+              range: { sheetId: newSheetId, dimension: 'ROWS', startIndex: 1, endIndex: 2 },
               inheritFromBefore: false,
             },
           },
@@ -186,20 +178,13 @@ async function createSheetFromTemplateOrBlank(authClient, sheetsList, title, pla
     },
   });
   const sheetId = addRes.data.replies?.[0]?.addSheet?.properties?.sheetId;
-  // Write platform label in A1 and dynamic headers in row 2
+  // Write platform label in A1
   await sheets.spreadsheets.values.update({
     spreadsheetId,
     auth: authClient,
     range: `${title}!A1:A1`,
     valueInputOption: 'USER_ENTERED',
     requestBody: { values: [[platformLabelFor(platformType)]] },
-  });
-  await sheets.spreadsheets.values.update({
-    spreadsheetId,
-    auth: authClient,
-    range: `${title}!A2:H2`,
-    valueInputOption: 'USER_ENTERED',
-    requestBody: { values: [headerRowFor(platformType)] },
   });
   await sheets.spreadsheets.batchUpdate({
     spreadsheetId,
@@ -224,7 +209,7 @@ async function readRows(authClient, title) {
     const res = await sheets.spreadsheets.values.get({
       spreadsheetId,
       auth: authClient,
-      range: `${title}!A3:J`,
+      range: `${title}!A2:J`,
     });
     return res.data.values || [];
   } catch (e) {
@@ -238,7 +223,7 @@ async function appendRows(authClient, title, rows) {
   await sheets.spreadsheets.values.append({
     spreadsheetId,
     auth: authClient,
-    range: `${title}!A4:J`,
+    range: `${title}!A3:J`,
     valueInputOption: 'USER_ENTERED',
     insertDataOption: 'INSERT_ROWS',
     requestBody: { values: rows },
@@ -838,7 +823,7 @@ async function processTab(authClient, title, entries, platformType) {
         requests: [
           {
             deleteDimension: {
-              range: { sheetId, dimension: 'ROWS', startIndex: 2, endIndex: 3 },
+              range: { sheetId, dimension: 'ROWS', startIndex: 1, endIndex: 2 },
             },
           },
         ],

--- a/.github/scripts/post-merge-validation-tracker.mjs
+++ b/.github/scripts/post-merge-validation-tracker.mjs
@@ -58,12 +58,20 @@ function tabTitleFor(repo, releaseLabel) {
   return `pre-${releaseLabel} (${repoType(repo)})`;
 }
 
+function platformLabelFor(type) {
+  const t = String(type).toLowerCase();
+  if (t === 'mobile') return '📱 Mobile - Pull requests';
+  if (t === 'extension') return '🔌 Extension - Pull requests';
+  return t;
+}
+
 function headerRowFor(type) {
-  const isMobile = String(type).toLowerCase() === 'mobile';
+  const t = String(type).toLowerCase();
+  const isMobile = t === 'mobile';
   const colG = isMobile ? 'Validated (Android)' : 'Validated (Chrome)';
   const colH = isMobile ? 'Validated (iOS)' : 'Validated (Firefox)';
   return [
-    'Pull Request',
+    platformLabelFor(type),
     'Merged Time (UTC)',
     'Author',
     'PR Size',
@@ -72,13 +80,6 @@ function headerRowFor(type) {
     colG,
     colH,
   ];
-}
-
-function platformLabelFor(type) {
-  const t = String(type).toLowerCase();
-  if (t === 'mobile') return '📱 Mobile - Pull requests';
-  if (t === 'extension') return '🔌 Extension - Pull requests';
-  return t;
 }
 
 async function ensureSheetExists(authClient, title, platformType) {
@@ -178,13 +179,13 @@ async function createSheetFromTemplateOrBlank(authClient, sheetsList, title, pla
     },
   });
   const sheetId = addRes.data.replies?.[0]?.addSheet?.properties?.sheetId;
-  // Write platform label in A1
+  // Write all column headers into row 1 (no template to provide them)
   await sheets.spreadsheets.values.update({
     spreadsheetId,
     auth: authClient,
-    range: `${title}!A1:A1`,
+    range: `${title}!A1:H1`,
     valueInputOption: 'USER_ENTERED',
-    requestBody: { values: [[platformLabelFor(platformType)]] },
+    requestBody: { values: [headerRowFor(platformType)] },
   });
   await sheets.spreadsheets.batchUpdate({
     spreadsheetId,

--- a/.github/scripts/post-merge-validation-tracker.mjs
+++ b/.github/scripts/post-merge-validation-tracker.mjs
@@ -130,13 +130,13 @@ async function createSheetFromTemplateOrBlank(authClient, sheetsList, title, pla
       },
     });
     const newSheetId = duplicateRes.data.replies?.[0]?.duplicateSheet?.properties?.sheetId;
-    // Write platform label in A1
+    // Write all platform-specific column headers into row 1 (preserves template cell formatting)
     await sheets.spreadsheets.values.update({
       spreadsheetId,
       auth: authClient,
-      range: `${title}!A1:A1`,
+      range: `${title}!A1:H1`,
       valueInputOption: 'USER_ENTERED',
-      requestBody: { values: [[platformLabelFor(platformType)]] },
+      requestBody: { values: [headerRowFor(platformType)] },
     });
     // Insert a blank row at index 1 (0-based) so data can start at row 3
     await sheets.spreadsheets.batchUpdate({


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The post validation tracker excel template was updated to use a single header row.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Google Sheets write/read ranges and row insert/delete indices, which can misalign headers vs appended PR data if the spreadsheet template differs from expectations. Changes are isolated to the post-merge tracking script and don’t affect production runtime code.
> 
> **Overview**
> Aligns the post-merge validation tracker spreadsheet format to a **single header row** by writing all headers (including the platform label) into row 1 and shifting data to start on row 3.
> 
> Updates sheet creation from template/blank to insert/delete the correct spacer row, and adjusts `readRows`/`appendRows` ranges accordingly so deduping and new PR inserts operate on the new row layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2f2298ef821f78b0223e223a8941f31fa75b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->