### PR TITLE
chore: scan more open PRs in release-branch-sync 

### DIFF
--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -112,6 +112,7 @@ get_active_release_branches() {
   pr_data=$(gh pr list \
     --state open \
     --limit 500 \
+    --search 'in:title release' \
     --json title,isDraft \
     --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title' \
     2>/dev/null || echo "")

--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -106,15 +106,6 @@ stable_has_new_commits() {
 get_active_release_branches() {
   local branches=""
   
-  # Query open and draft PRs with title starting with "release:" (case-insensitive)
-  # The jq filter extracts version from PR titles like "release: 7.36.0" or "Release: 7.36.0 (#1234)"
-  #
-  # `--limit` must be high enough that the next release PR is always in the
-  # result set. The default `gh pr list` limit is 30, which is not enough for
-  # busy repos (e.g. metamask-extension) where the release PR is often older
-  # than the 30 most-recently-created open PRs — in that case the script would
-  # silently log "No active release branches found" and exit without creating
-  # any sync PR. See https://consensyssoftware.atlassian.net/browse/MCRM-66.
   local pr_data
   pr_data=$(gh pr list \
     --state open \

--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -106,6 +106,8 @@ stable_has_new_commits() {
 get_active_release_branches() {
   local branches=""
   
+  # Query open and draft PRs with title starting with "release:" (case-insensitive)
+  # The jq filter extracts version from PR titles like "release: 7.36.0" or "Release: 7.36.0 (#1234)"
   local pr_data
   pr_data=$(gh pr list \
     --state open \

--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -108,9 +108,17 @@ get_active_release_branches() {
   
   # Query open and draft PRs with title starting with "release:" (case-insensitive)
   # The jq filter extracts version from PR titles like "release: 7.36.0" or "Release: 7.36.0 (#1234)"
+  #
+  # `--limit` must be high enough that the next release PR is always in the
+  # result set. The default `gh pr list` limit is 30, which is not enough for
+  # busy repos (e.g. metamask-extension) where the release PR is often older
+  # than the 30 most-recently-created open PRs — in that case the script would
+  # silently log "No active release branches found" and exit without creating
+  # any sync PR. See https://consensyssoftware.atlassian.net/browse/MCRM-66.
   local pr_data
   pr_data=$(gh pr list \
     --state open \
+    --limit 500 \
     --json title,isDraft \
     --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title' \
     2>/dev/null || echo "")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `release-branch-sync` action silently skipping the next release PR when the repo has many open PRs. `gh pr list` was called without `--limit` and defaulted to 30 results, so the next release PR could fall outside the returned set. This caused hotfix sync PRs (e.g. `release/13.20.1` → `release/13.21.0` on metamask-extension) not to be auto-created. Now scans up to 500 open PRs ([MCRM-66](https://consensyssoftware.atlassian.net/browse/MCRM-66)).
+
 ## [1.9.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix `release-branch-sync` action silently skipping the next release PR when the repo has many open PRs. `gh pr list` was called without `--limit` and defaulted to 30 results, so the next release PR could fall outside the returned set. This caused hotfix sync PRs (e.g. `release/13.20.1` → `release/13.21.0` on metamask-extension) not to be auto-created. Now scans up to 500 open PRs ([MCRM-66](https://consensyssoftware.atlassian.net/browse/MCRM-66)).
-
 ## [1.9.2]
 
 ### Changed


### PR DESCRIPTION
## Summary

After a release PR is merged into `stable`, the `release-branch-sync` action sometimes silently exits without creating a sync PR for the next open release branch.

## Root cause

`gh pr list` defaults to **30 results** when `--limit` is not passed. In a busy repo, the next release PR is often older than the 30 most-recently-created open PRs and falls outside that window. The script then logs:
WARNING: No active release branches found (no open/draft PRs with 'release: X.Y.Z' title) and exits cleanly, creating no sync PRs.

This is what happened after `release/13.29.0` was merged on the extension repo:
- [Action run 73942085340](https://github.com/MetaMask/metamask-extension/actions/runs/25217752404/job/73942085340) — succeeded, but logged "No active release branches found".
so i created the stable sync PR manually: https://github.com/MetaMask/metamask-extension/pull/42124

## Fix

Add `--limit 500` to the `gh pr list` call .


---

> [!NOTE]
> **Low Risk**
> Low risk: small, scoped change to the `release-branch-sync` automation that only increases the PR scan window, with minimal behavioral impact beyond finding older release PRs in busy repos.
> 
> **Overview**
> Prevents the `release-branch-sync` script from silently missing active release PRs in repos with lots of open PRs by raising `gh pr list`’s fetch size to `--limit 500` and documenting the rationale.
> 
> Adds a corresponding **Unreleased** changelog entry describing the bug and fix (MCRM-66).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19b27c77e0d7cf37d2dfe81d48e98d2e8e7c996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->