### PR TITLE
fix: skip missing mobile bitrise files in stable-sync

### DIFF
--- a/.github/scripts/stable-sync.js
+++ b/.github/scripts/stable-sync.js
@@ -87,9 +87,6 @@ async function runGitCommands() {
       console.log('Executing mobile-specific commands...');
 
       // Preserve these files from main to avoid showing them as changes in the PR
-      await exec(`git checkout origin/main -- bitrise.yml`);
-      console.log(`Executed: git checkout origin/main -- bitrise.yml`);
-
       await exec(`git checkout origin/main -- android/app/build.gradle`);
       console.log(`Executed: git checkout origin/main -- android/app/build.gradle`);
 


### PR DESCRIPTION
## Problem

After [MetaMask/metamask-mobile#30204](https://github.com/MetaMask/metamask-mobile/pull/30204) (*chore: Remove all bitrise artifacts*) deleted `bitrise.yml` from the mobile repo, every run of the **Stable Branch Sync** workflow now fails on the mobile repo with:

```
Executing mobile-specific commands...
Error: Command failed: git checkout origin/main -- bitrise.yml
error: pathspec 'bitrise.yml' did not match any file(s) known to git
```
Solution is to drop the now-stale `bitrise.yml` entry from the preserve list.


Behavior for other repos (`REPO !== 'mobile'`) is unchanged.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a737ad679a44da94b303aba842bfbb84b6d47e93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->