### PR TITLE
feat: add `rename-after-install-and-build` input to `publish-preview.yml` workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -108,7 +108,7 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Install dependencies (snap, pre-build)
+      - name: Install dependencies (pre-build)
         if: ${{ inputs.rename-after-install-and-build }}
         run: yarn install --no-immutable
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -112,6 +112,18 @@ jobs:
         if: ${{ inputs.rename-after-install-and-build }}
         run: yarn install --no-immutable
 
+      - name: Mask build environment values
+        env:
+          BUILD_ENV: ${{ secrets.BUILD_ENV }}
+        run: |
+          if [[ -n "$BUILD_ENV" ]]; then
+            while IFS= read -r line; do
+              if [[ -n "$line" ]]; then
+                echo "::add-mask::$line"
+              fi
+            done < <(jq --raw-output '.[] | tostring' <<< "$BUILD_ENV")
+          fi
+
       - name: Build (snap, pre-rename)
         if: ${{ inputs.rename-after-install-and-build }}
         env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -109,11 +109,11 @@ jobs:
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies (snap, pre-build)
-        if: ${{ inputs.is-snap }}
+        if: ${{ inputs.rename-after-install-and-build }}
         run: yarn install --no-immutable
 
       - name: Build (snap, pre-rename)
-        if: ${{ inputs.is-snap }}
+        if: ${{ inputs.rename-after-install-and-build }}
         env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}
         run: ${{ inputs.build-command }}
 
@@ -160,7 +160,7 @@ jobs:
         run: yarn install --no-immutable
 
       - name: Build
-        if: ${{ !inputs.is-snap }}
+        if: ${{ !inputs.rename-after-install-and-build }}
         env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}
         run: ${{ inputs.build-command }}
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         required: false
         default: true
+      is-snap:
+        description: 'Whether the consumer is a Snap. When true, the build runs before manifests are renamed so that snap artifacts (e.g. dist/bundle.js, snap.manifest.json) capture the original package name.'
+        type: boolean
+        required: false
+        default: false
       environment:
         description: 'GitHub environment for the publish job (e.g., default-branch). Empty = no gate.'
         type: string
@@ -100,7 +105,15 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare preview builds
+      - name: Install dependencies (snap, pre-build)
+        if: ${{ inputs.is-snap }}
+        run: yarn install --no-immutable
+
+      - name: Build (snap, pre-rename)
+        if: ${{ inputs.is-snap }}
+        run: ${{ inputs.build-command }}
+
+      - name: Prepare preview manifests
         env:
           NPM_SCOPE: ${{ inputs.npm-scope }}
           COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
@@ -139,10 +152,11 @@ jobs:
             prepare_manifest package.json
           fi
 
-          echo "Installing dependencies..."
-          yarn install --no-immutable
+      - name: Install dependencies
+        run: yarn install --no-immutable
 
       - name: Build
+        if: ${{ !inputs.is-snap }}
         run: ${{ inputs.build-command }}
 
       - name: Upload build artifacts (monorepo)

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -23,8 +23,8 @@ on:
         type: boolean
         required: false
         default: true
-      is-snap:
-        description: 'Whether the consumer is a Snap. When true, the build runs before manifests are renamed so that snap artifacts (e.g. dist/bundle.js, snap.manifest.json) capture the original package name.'
+      rename-after-install-and-build:
+        description: 'Governs where in the workflow that packages in the repo are renamed to use the preview build scope. If true, this step runs after the install and build steps; if false (default), it runs before. This option is mostly for Snaps so that artifacts (e.g. dist/bundle.js, snap.manifest.json) capture the original package name, not the preview build name.'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -124,7 +124,7 @@ jobs:
             done < <(jq --raw-output '.[] | tostring' <<< "$BUILD_ENV")
           fi
 
-      - name: Build (snap, pre-rename)
+      - name: Build (pre-rename)
         if: ${{ inputs.rename-after-install-and-build }}
         env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}
         run: ${{ inputs.build-command }}
@@ -171,7 +171,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --no-immutable
 
-      - name: Build
+      - name: Build (post-rename)
         if: ${{ !inputs.rename-after-install-and-build }}
         env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}
         run: ${{ inputs.build-command }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -51,6 +51,9 @@ on:
     secrets:
       PUBLISH_PREVIEW_NPM_TOKEN:
         required: true
+      BUILD_ENV:
+        description: 'JSON object of environment variables to pass to the build step (e.g. ''{"FOO":"bar","API_URL":"https://..."}''). Use this for build-time configuration and secrets needed by the build command.'
+        required: false
 
 jobs:
   is-fork-pull-request:
@@ -111,6 +114,7 @@ jobs:
 
       - name: Build (snap, pre-rename)
         if: ${{ inputs.is-snap }}
+        env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}
         run: ${{ inputs.build-command }}
 
       - name: Prepare preview manifests
@@ -157,6 +161,7 @@ jobs:
 
       - name: Build
         if: ${{ !inputs.is-snap }}
+        env: ${{ fromJSON(secrets.BUILD_ENV || '{}') }}
         run: ${{ inputs.build-command }}
 
       - name: Upload build artifacts (monorepo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `is-snap` input to the `publish-preview` reusable workflow ([#254](https://github.com/MetaMask/github-tools/pull/254))
+- Add `rename-after-install-and-build` input to the `publish-preview` reusable workflow ([#254](https://github.com/MetaMask/github-tools/pull/254))
   - When set to `true`, the workflow installs dependencies and runs the build _before_ renaming workspace manifests to the preview NPM scope. This ensures snap artifacts (e.g. `dist/bundle.js`, `snap.manifest.json` and its `source.shasum`) are produced with the original `@metamask/...` package name.
   - Defaults to `false` to preserve existing behavior for non-snap consumers.
 - Add `BUILD_ENV` secret input to the `publish-preview` reusable workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `is-snap` input to the `publish-preview` reusable workflow
   - When set to `true`, the workflow installs dependencies and runs the build _before_ renaming workspace manifests to the preview NPM scope. This ensures snap artifacts (e.g. `dist/bundle.js`, `snap.manifest.json` and its `source.shasum`) are produced with the original `@metamask/...` package name.
   - Defaults to `false` to preserve existing behavior for non-snap consumers.
+- Add `BUILD_ENV` secret input to the `publish-preview` reusable workflow
+  - Accepts a JSON object of environment variables that will be passed to the build step (e.g. `'{"API_URL":"https://...","LOG_LEVEL":"all"}'`). Useful when the build command needs additional configuration or secret values to produce a valid preview build.
 
 ## [1.9.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `is-snap` input to the `publish-preview` reusable workflow
+- Add `is-snap` input to the `publish-preview` reusable workflow ([#254](https://github.com/MetaMask/github-tools/pull/254))
   - When set to `true`, the workflow installs dependencies and runs the build _before_ renaming workspace manifests to the preview NPM scope. This ensures snap artifacts (e.g. `dist/bundle.js`, `snap.manifest.json` and its `source.shasum`) are produced with the original `@metamask/...` package name.
   - Defaults to `false` to preserve existing behavior for non-snap consumers.
 - Add `BUILD_ENV` secret input to the `publish-preview` reusable workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `is-snap` input to the `publish-preview` reusable workflow
+  - When set to `true`, the workflow installs dependencies and runs the build _before_ renaming workspace manifests to the preview NPM scope. This ensures snap artifacts (e.g. `dist/bundle.js`, `snap.manifest.json` and its `source.shasum`) are produced with the original `@metamask/...` package name.
+  - Defaults to `false` to preserve existing behavior for non-snap consumers.
+
 ## [1.9.4]
 
 ### Fixed


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The reusable publish-preview workflow renames each workspace's package.json#name from `@metamask/...` to `@metamask-previews/...` before running the build. This works for typical libraries but breaks for Snap packages, because:
- The Snap build (mm-snap build) embeds the package name into dist/bundle.js.
- snap.manifest.json contains a source.shasum computed over the bundle, the manifest itself (minus the shasum), the icon, and locales.
- source.location.npm.packageName in the manifest must match package.json#name at publish time.
When the rename happens before the build, the bundle and manifest are produced against the preview scope, the shasum is computed over the contaminated bundle, and downstream clients that verify against the published @metamask/... shasum reject the snap.
The workaround used by snap repos today (e.g. snap-tron-wallet) is to build first, then rename — but the reusable workflow had no way to express that ordering.

To fix this issue and make this workflow usable for Snaps, this PR adds a new boolean input `rename-after-install-and-build ` (default false) to `.github/workflows/publish-preview.yml`.

Existing consumers don't need to change anything. Snap consumers add a single input:
```yaml
jobs:
  publish-preview:
    uses: MetaMask/github-tools/.github/workflows/publish-preview.yml
    with:
      rename-after-install-and-build: true
    secrets:
      PUBLISH_PREVIEW_NPM_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI ordering for preview builds and introduces secret env injection into build steps; default path is unchanged but misconfigured BUILD_ENV or rename ordering could break consumer preview builds.
> 
> **Overview**
> Extends the reusable **`publish-preview`** workflow so consumers can control **when** package names are rewritten to the preview NPM scope, and can inject **build-time environment** from secrets.
> 
> Adds **`rename-after-install-and-build`** (default `false`). When `true`, the job runs **install → build → manifest rename → install** so artifacts like Snap bundles and `snap.manifest.json` are built under the original `@metamask/...` name before preview renaming. When `false`, behavior stays **rename → install → build**.
> 
> Adds optional secret **`BUILD_ENV`** (JSON key/value map) applied to the build step via `fromJSON`, with a step that **masks** those values in logs. The prepare step is renamed to **Prepare preview manifests**; install/build are split into conditional pre-rename and post-rename steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9994d8ba62e5a2a3ba881e23f8e773f3b38b7472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->