### PR TITLE
feat: Add action to get short-lived access token using OIDC

### DIFF
--- a/.github/actions/get-token/action.yml
+++ b/.github/actions/get-token/action.yml
@@ -48,13 +48,12 @@ runs:
           // contents: read
           // issues: write
           // ```
-          const requestedPermissions = REQUESTED_PERMISSIONS
-            .split('\n')
-            .filter(line => line.trim() !== '')
-            .map(line => {
-              const [scope, permission] = line.split(':').map(part => part.trim());
-              return { scope, permission };
-            });
+          const requestedPermissions = Object.fromEntries(
+            REQUESTED_PERMISSIONS
+              .split('\n')
+              .filter(line => line.trim() !== '')
+              .map(line => line.split(':').map(part => part.trim()))
+          );
 
           const response = await fetch(`${TOKEN_EXCHANGE_URL}/api/exchange/token`, {
             method: 'POST',

--- a/.github/actions/get-token/action.yml
+++ b/.github/actions/get-token/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/github-script@v9
       with:
         script: |
-          const token = await core.getIDToken();
+          const token = await core.getIDToken('api://token-exchange-service');
           core.setSecret(token);
           core.setOutput('token', token);
 

--- a/.github/actions/get-token/action.yml
+++ b/.github/actions/get-token/action.yml
@@ -82,5 +82,3 @@ runs:
           core.setOutput('token', token);
 
           core.info(`Access token obtained successfully. Token expires at: "${expires_at}".`);
-
-

--- a/.github/actions/get-token/action.yml
+++ b/.github/actions/get-token/action.yml
@@ -1,0 +1,86 @@
+name: Get Token
+description: 'Get a short-lived access token to interact with the GitHub API. Note: Using this action requires the "id-token: write" permission to be set for the GitHub Actions workflow job.'
+
+inputs:
+  token-exchange-url:
+    description: 'The URL to exchange the OIDC token for an access token.'
+    required: true
+  permissions:
+    description: 'The permissions to request for the access token, in the format of "scope: permission", separated by newlines.'
+    required: true
+
+outputs:
+  token:
+    value: '${{ steps.access-token.outputs.token }}'
+    description: 'The short-lived access token obtained from the token exchange service.'
+
+runs:
+  using: composite
+  steps:
+    - name: Get OIDC token
+      id: oidc-token
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const token = await core.getIDToken();
+          core.setSecret(token);
+          core.setOutput('token', token);
+
+    - name: Exchange OIDC token
+      id: access-token
+      uses: actions/github-script@v9
+      env:
+        OIDC_TOKEN: ${{ steps.oidc-token.outputs.token }}
+        TOKEN_EXCHANGE_URL: ${{ inputs.token-exchange-url }}
+        REQUESTED_PERMISSIONS: ${{ inputs.permissions }}
+      with:
+        script: |
+          const {
+            GITHUB_REPOSITORY,
+            OIDC_TOKEN,
+            TOKEN_EXCHANGE_URL,
+            REQUESTED_PERMISSIONS,
+          } = process.env;
+
+          // This assumes `REQUESTED_PERMISSIONS` is a newline-separated string
+          // of "scope: permission" pairs, e.g.:
+          // ```
+          // contents: read
+          // issues: write
+          // ```
+          const requestedPermissions = REQUESTED_PERMISSIONS
+            .split('\n')
+            .filter(line => line.trim() !== '')
+            .map(line => {
+              const [scope, permission] = line.split(':').map(part => part.trim());
+              return { scope, permission };
+            });
+
+          const response = await fetch(`${TOKEN_EXCHANGE_URL}/api/exchange/token`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              oidcToken: OIDC_TOKEN,
+              targetRepo: GITHUB_REPOSITORY,
+              requested_permissions: requestedPermissions,
+            }),
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            return core.setFailed(`Token exchange failed: ${response.status} ${response.statusText} - ${errorText}`);
+          }
+
+          const { token, permissions, expires_at, } = await response.json();
+          if (!token) {
+            return core.setFailed('Token exchange response did not contain an access token.');
+          }
+
+          core.setSecret(token);
+          core.setOutput('token', token);
+
+          core.info(`Access token obtained successfully. Token expires at: "${expires_at}".`);
+
+

--- a/.github/actions/get-token/action.yml
+++ b/.github/actions/get-token/action.yml
@@ -8,6 +8,10 @@ inputs:
   permissions:
     description: 'The permissions to request for the access token, in the format of "scope: permission", separated by newlines.'
     required: true
+  target-repository:
+    description: 'The repository to target for the access token. Defaults to the current repository.'
+    required: false
+    default: '${{ github.repository }}'
 
 outputs:
   token:
@@ -33,13 +37,14 @@ runs:
         OIDC_TOKEN: ${{ steps.oidc-token.outputs.token }}
         TOKEN_EXCHANGE_URL: ${{ inputs.token-exchange-url }}
         REQUESTED_PERMISSIONS: ${{ inputs.permissions }}
+        TARGET_REPOSITORY: ${{ inputs.target-repository }}
       with:
         script: |
           const {
-            GITHUB_REPOSITORY,
             OIDC_TOKEN,
             TOKEN_EXCHANGE_URL,
             REQUESTED_PERMISSIONS,
+            TARGET_REPOSITORY,
           } = process.env;
 
           // This assumes `REQUESTED_PERMISSIONS` is a newline-separated string
@@ -62,7 +67,7 @@ runs:
             },
             body: JSON.stringify({
               oidcToken: OIDC_TOKEN,
-              targetRepo: GITHUB_REPOSITORY,
+              targetRepo: TARGET_REPOSITORY,
               requested_permissions: requestedPermissions,
             }),
           });


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This adds a workflow to get a short-lived GitHub access token using `token-exchange-service`. Example workflow below:

```yaml
name: Token exchange test

on:
  pull_request:

jobs:
  test:
    name: Test token exchange
    runs-on: ubuntu-latest
    permissions:
      id-token: write
    steps:
      - uses: MetaMask/github-tools/.github/actions/get-token@v1
        id: token-exchange
        with:
          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
          permissions: |
            contents: read
            pull_requests: write

      - name: Comment on pull request
        uses: actions/github-script@v8
        with:
          github-token: ${{ steps.token-exchange.outputs.token }}
          script: |
            const prNumber = 1;
            const commentBody = 'This is a test comment using the exchanged token.';
            await github.rest.issues.createComment({
              ...context.repo,
              issue_number: prNumber,
              body: commentBody,
            });
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a CI path that mints GitHub tokens with caller-chosen permissions; misuse or overly broad scopes in consuming workflows could expand blast radius, though tokens are short-lived and the action itself is additive.
> 
> **Overview**
> Adds a new reusable composite GitHub Action **Get Token** (`.github/actions/get-token`) so workflows can obtain **short-lived GitHub API access tokens** via OIDC and an external token exchange service instead of long-lived PATs.
> 
> The action requests an OIDC token (`api://token-exchange-service`), POSTs it to `{token-exchange-url}/api/exchange/token` with newline-parsed `scope: permission` pairs and an optional target repo, then exposes the returned token as a step output (masked with `core.setSecret`). Callers must grant **`id-token: write`** on the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bfb594eb4d316d929ee191c77383b17c6237a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->