### PR TITLE
feat: Add optional `planning-token` to Add Team Label action

### DIFF
--- a/.github/actions/add-team-label/action.yml
+++ b/.github/actions/add-team-label/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: 'GitHub token with access to read topology.json and add labels to PRs.'
     required: true
 
+  planning-token:
+    description: 'GitHub token with access to read topology.json. Optional if team-label-token already has this access.'
+    required: false
+    default: ${{ inputs.team-label-token }}
+
 runs:
   using: composite
   steps:
@@ -13,7 +18,7 @@ runs:
     - name: Get team label
       id: get-team-label
       env:
-        GH_TOKEN: ${{ inputs.team-label-token }}
+        GH_TOKEN: ${{ inputs.planning-token }}
         USER: ${{ github.event.pull_request.user.login }}
       shell: bash
       run: |

--- a/.github/actions/add-team-label/action.yml
+++ b/.github/actions/add-team-label/action.yml
@@ -9,7 +9,6 @@ inputs:
   planning-token:
     description: 'GitHub token with access to read topology.json. Optional if team-label-token already has this access.'
     required: false
-    default: ${{ inputs.team-label-token }}
 
 runs:
   using: composite
@@ -18,7 +17,7 @@ runs:
     - name: Get team label
       id: get-team-label
       env:
-        GH_TOKEN: ${{ inputs.planning-token }}
+        GH_TOKEN: ${{ inputs.planning-token || inputs.team-label-token }}
         USER: ${{ github.event.pull_request.user.login }}
       shell: bash
       run: |


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

With `token-exchange-service` we can only target a single repository per token, meaning we can't generate a token that can access both `MetaMask/metamask-mobile` (to add the label) _and_ `MetaMask/metamask-planning` (to read the topology file). To support this, we need to use two separate tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI composite-action input change; backward compatible when planning-token is omitted.
> 
> **Overview**
> Adds an optional **`planning-token`** input to the **Add Team Label** composite action so workflows can use **two GitHub tokens** when a single token cannot reach both repos (e.g. `token-exchange-service` scoped to one repository).
> 
> The **Get team label** step now authenticates with `planning-token` when provided, otherwise falls back to `team-label-token`, for the `gh api` call that reads `topology.json` from **MetaMask/metamask-planning**. The **Add team label** step is unchanged and still uses **`team-label-token`** only to apply the label on the PR.
> 
> Callers that already have one token with access to both planning and the target repo do not need to pass the new input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a22bcda99a3353dca19151856286af7d6f0466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->