### PR TITLE
chore: bump actionlint to 1.7.12 in lint-workflows

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash)
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
         shell: bash
 
       - name: Lint workflow files

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.7.7
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.7.12
         shell: bash
 
       - name: Lint workflow files

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.7.12
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7/scripts/download-actionlint.bash) 1.7.12
         shell: bash
 
       - name: Lint workflow files

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7/scripts/download-actionlint.bash) 1.7.12
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash)
         shell: bash
 
       - name: Lint workflow files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `actionlint` from `1.7.7` to `1.7.12` in the `lint-workflows` workflow ([#259](https://github.com/MetaMask/github-tools/pull/259))
+
 ## [1.11.0]
 
 ### Added


### PR DESCRIPTION
## Description

Bumps `actionlint` from `1.7.7` to `1.7.12` in the reusable `lint-workflows` workflow to pick up support for newer GitHub Actions features.

The `download-actionlint.bash` script ref is unchanged; only the pinned `actionlint` version it installs is bumped.

## Changes

- `.github/workflows/lint-workflows.yml`: `1.7.7` → `1.7.12`
- `CHANGELOG.md`: add entry under `[Unreleased]`

## Notes

This is a non-breaking change, so it should land in the next `minor` release (`1.12.0`). Consumers referencing the reusable workflow via `@v1` will pick it up automatically once released.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency version bump with no application, auth, or data-handling changes.
> 
> **Overview**
> Updates the reusable **`lint-workflows`** workflow so CI installs **actionlint `1.7.12`** instead of **`1.7.7`**, and pins the upstream **`download-actionlint.bash`** script to a newer commit on the rhysd/actionlint repo. A **`[Unreleased]`** changelog entry documents the bump.
> 
> Consumers that call this workflow (e.g. **`main.yml`**) get stricter or more accurate workflow linting for newer GitHub Actions syntax without changing workflow structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc393dba3c6420cd0f991760b2d964886975bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->