### PR TITLE
chore: accept release ota branch

### DIFF
--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -21,8 +21,8 @@
 
 set -e
 
-# Regex pattern for valid release branch names (release/X.Y.Z)
-RELEASE_BRANCH_PATTERN='^release/[0-9]+\.[0-9]+\.[0-9]+$'
+# Regex pattern for valid release branch names (release/X.Y.Z or release/X.Y.Z-ota)
+RELEASE_BRANCH_PATTERN='^release/[0-9]+\.[0-9]+\.[0-9]+(-ota)?$'
 
 # -----------------------------------------------------------------------------
 # Helper Functions
@@ -71,10 +71,10 @@ pr_exists() {
   [[ "$existing_pr" -gt 0 ]]
 }
 
-# Parse version from release branch name (release/X.Y.Z -> X.Y.Z)
+# Parse version from release branch name (release/X.Y.Z or release/X.Y.Z-ota -> X.Y.Z)
 parse_version() {
   local branch=$1
-  echo "$branch" | sed 's|release/||'
+  echo "$branch" | sed 's|release/||' | sed 's|-ota$||'
 }
 
 # Compare two semantic versions
@@ -107,14 +107,15 @@ get_active_release_branches() {
   local branches=""
   
   # Query open and draft PRs with title starting with "release:" (case-insensitive)
-  # The jq filter extracts version from PR titles like "release: 7.36.0" or "Release: 7.36.0 (#1234)"
+  # The jq filter extracts version from PR titles like "release: 7.36.0", "Release: 7.36.0 (#1234)",
+  # or OTA variants like "release: 7.81.1-ota"
   local pr_data
   pr_data=$(gh pr list \
     --state open \
     --limit 500 \
     --search 'in:title release' \
     --json title,isDraft \
-    --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title' \
+    --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+(-ota)?"; "i")) | .title' \
     2>/dev/null || echo "")
   
   if [[ -z "$pr_data" ]]; then
@@ -125,11 +126,11 @@ get_active_release_branches() {
   # Extract version numbers from PR titles and convert to branch names
   while IFS= read -r title; do
     if [[ -n "$title" ]]; then
-      # Extract version (X.Y.Z) from title - jq already validated the format,
-      # so we just need to extract the first semantic version pattern.
+      # Extract version (X.Y.Z or X.Y.Z-ota) from title - jq already validated the format,
+      # so we just need to extract the first semantic version pattern (with optional -ota suffix).
       # Using grep -oE is case-agnostic and simpler than matching "release:" variations.
       local version
-      version=$(echo "$title" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+      version=$(echo "$title" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-ota)?' | head -1)
       if [[ -n "$version" ]]; then
         local branch="release/${version}"
         # Only add if not already in list (use grep -Fx for exact string matching,


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
accept release ota branch naming convention for OTA releases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only bash regex and parsing changes with no runtime product impact; incorrect patterns could skip or mis-target OTA sync PRs.
> 
> **Overview**
> Extends **release-branch-sync** so OTA releases use the `release/X.Y.Z-ota` naming convention end-to-end.
> 
> Validation now accepts branches like `release/7.81.1-ota`, and **`parse_version`** strips the `-ota` suffix so semver comparisons still work against standard releases. Discovery of active releases from open PRs titled `release: …` was updated in the **jq** filter and **grep** extraction to include optional `-ota`, mapping those PRs to `release/${version}` branches (including the suffix when present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f1da06b146a17f0d6e18e4e5fc996567e6ddb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->