### PR TITLE
fix: overwrite existing stable-sync PR instead of skipping successive syncs

### DIFF
--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -176,7 +176,7 @@ If there are conflicts, they will appear in this PR. Resolve them to ensure the 
 }
 
 # Process a single release branch
-# Returns: 0 = PR created, 1 = failed, 2 = skipped
+# Returns: 0 = PR created or refreshed, 1 = failed, 2 = skipped
 process_release_branch() {
   local release_branch=$1
   local merged_version=$2
@@ -212,12 +212,6 @@ process_release_branch() {
   # Create sync branch name (replace / with -)
   local sync_branch="stable-sync-${release_branch//\//-}"
   
-  # Check if a sync PR already exists
-  if pr_exists "$release_branch" "$sync_branch"; then
-    log_warning "Sync PR already exists for ${release_branch}, skipping"
-    return 2
-  fi
-  
   # Check if stable has any new commits compared to the release branch
   if ! stable_has_new_commits "$release_branch"; then
     log_success "${release_branch} is already up-to-date with stable, no sync needed"
@@ -236,13 +230,21 @@ process_release_branch() {
   # Create sync branch from stable
   git checkout -b "$sync_branch" origin/stable
   
-  # Push the sync branch (force in case it exists remotely)
+  # Push the sync branch (force in case it exists remotely). This overwrites the
+  # remote branch and refreshes any open PR already pointing at it.
   log_info "Pushing ${sync_branch}..."
   if git push -u origin "$sync_branch" --force; then
     log_success "Pushed ${sync_branch}"
   else
     log_error "Failed to push ${sync_branch}"
     return 1
+  fi
+  
+  # If a sync PR already exists, the force-push above just refreshed it, so we're
+  # done. Creating a new PR would fail on the duplicate head branch.
+  if pr_exists "$release_branch" "$sync_branch"; then
+    log_success "Refreshed existing sync PR for ${release_branch}"
+    return 0
   fi
   
   # Create the PR (stable-sync branch → release branch)


### PR DESCRIPTION
### Problem
`release-branch-sync.sh` derives the sync branch name from the target release branch (`stable-sync-release-X.Y.Z`), so every sync into a given release branch reuses the same branch. The function bailed early via `pr_exists` whenever a sync PR already existed.

When multiple patch releases merge into `stable` in sequence, each one targets the same open release branch. The second sync hit the early `return 2` and **silently skipped**, dropping the newer `stable` changes.

Example: `release/13.35.0` merges and syncs into `release/13.36.0` (PR created). Later `release/13.35.1` merges, tries to sync into `release/13.36.0` again, sees the still-open PR, and skips — so `13.35.1`'s changes never reach `release/13.36.0`.

### Fix
- Removed the early `pr_exists` bail so successive syncs are no longer dropped.
- Kept the `stable_has_new_commits` guard (still skips when there's nothing new).
- The script already force-pushes the sync branch, which overwrites the remote branch and refreshes any open PR pointing at it. After the push, we check `pr_exists` once: if a PR already exists it was just refreshed, so we log success and `return 0` instead of calling `create_sync_pr` (which would fail on a duplicate head). Otherwise the PR is created as before.
- Updated the `process_release_branch` return-code comment to `0 = PR created or refreshed`.

The sync branch is bot-owned and always equals `origin/stable`, so regenerating it on every run is a pure refresh — no manual work lives there to lose.

### Validation
- `bash -n .github/scripts/release-branch-sync.sh` passes.
- `shellcheck` not available in the local environment.

### Rollout
This script is consumed by `metamask-extension`'s `release-branch-sync.yml` via `@v1`, so this must land on the default branch **and** be released to the `v1` tag to take effect.