### PR TITLE
chore: drop bitrise.yml dependency

### DIFF
--- a/.github/actions/stable-sync/action.yml
+++ b/.github/actions/stable-sync/action.yml
@@ -133,7 +133,6 @@ runs:
 
         Preserves specific files from the stable branch:
           - CHANGELOG.md
-          - bitrise.yml
           - android/app/build.gradle
           - ios/MetaMask.xcodeproj/project.pbxproj
           - package.json

--- a/.github/scripts/create-platform-release-pr.sh
+++ b/.github/scripts/create-platform-release-pr.sh
@@ -79,7 +79,7 @@ get_expected_changed_files() {
   local expected_changed_files=""
 
   if [[ "$platform" == "mobile" ]]; then
-    expected_changed_files="package.json android/app/build.gradle ios/MetaMask.xcodeproj/project.pbxproj bitrise.yml"
+    expected_changed_files="package.json android/app/build.gradle ios/MetaMask.xcodeproj/project.pbxproj"
   elif [[ "$platform" == "extension" ]]; then
     expected_changed_files="package.json"
   else

--- a/.github/scripts/set-mobile-build-version.sh
+++ b/.github/scripts/set-mobile-build-version.sh
@@ -26,7 +26,6 @@ SEMVER_REGEX="\
 
 PACKAGE_JSON_FILE=package.json
 ANDROID_BUILD_GRADLE_FILE=android/app/build.gradle
-BITRISE_YML_FILE=bitrise.yml
 IOS_PROJECT_FILE=ios/MetaMask.xcodeproj/project.pbxproj
 
 semver_to_nat () {
@@ -51,12 +50,6 @@ update_mobile_files () {
     sed -i '' -E "s/(\s*versionCode )[0-9]+/\1$VERSION_NUMBER/" $ANDROID_BUILD_GRADLE_FILE
     echo "- $ANDROID_BUILD_GRADLE_FILE successfully updated"
 
-    # update bitrise.yml
-    echo "Updating Bitrise configuration files..."
-    sed -i '' -E "s/(\s*VERSION_NUMBER: )[0-9]+/\1$VERSION_NUMBER/" $BITRISE_YML_FILE
-    sed -i '' -E "s/(\s*FLASK_VERSION_NUMBER: )[0-9]+/\1$VERSION_NUMBER/" $BITRISE_YML_FILE
-    echo "- $BITRISE_YML_FILE successfully updated"
-
     # update ios/MetaMask.xcodeproj/project.pbxproj
     echo "Updating iOS project settings..."
     sed -i '' -E "s/(\s*CURRENT_PROJECT_VERSION = )[0-9]+/\1$VERSION_NUMBER/" $IOS_PROJECT_FILE
@@ -70,12 +63,6 @@ update_mobile_files () {
     sed -i -E "s/(\s*versionCode )[0-9]+/\1$VERSION_NUMBER/" $ANDROID_BUILD_GRADLE_FILE
     echo "- $ANDROID_BUILD_GRADLE_FILE successfully updated"
 
-    # update bitrise.yml
-    echo "Updating Bitrise configuration files..."
-    sed -i -E "s/(\s*VERSION_NUMBER: )[0-9]+/\1$VERSION_NUMBER/" $BITRISE_YML_FILE
-    sed -i -E "s/(\s*FLASK_VERSION_NUMBER: )[0-9]+/\1$VERSION_NUMBER/" $BITRISE_YML_FILE
-    echo "- $BITRISE_YML_FILE successfully updated"
-
     # update ios/MetaMask.xcodeproj/project.pbxproj
     echo "Updating iOS project settings..."
     sed -i -E "s/(\s*CURRENT_PROJECT_VERSION = )[0-9]+/\1$VERSION_NUMBER/" $IOS_PROJECT_FILE
@@ -86,16 +73,10 @@ update_mobile_files () {
   echo "All specified files updated with version number: $VERSION_NUMBER"
 }
 
-# get current numbers
-CURRENT_VERSION_NUMBER=$(awk '/^\s+VERSION_NUMBER: /{print $2}' $BITRISE_YML_FILE);
-CURRENT_FLASK_VERSION_NUMBER=$(awk '/^\s+FLASK_VERSION_NUMBER: /{print $2}' $BITRISE_YML_FILE);
-
-# ensure version number of main variant and flask are aligned
-if [[ "$CURRENT_VERSION_NUMBER" != "$CURRENT_FLASK_VERSION_NUMBER" ]]; then
-  echo "VERSION_NUMBER $CURRENT_VERSION_NUMBER and FLASK_VERSION_NUMBER $CURRENT_FLASK_VERSION_NUMBER should be the same"
-  log_and_exit "Check why they are different and fix it before proceeding"
-fi
-
+# Extract current build numbers from Android and iOS sources of truth.
+# Use POSIX [[:space:]] for cross-platform awk compatibility (macOS BSD awk doesn't support \s).
+CURRENT_ANDROID_VERSION_NUMBER=$(awk '/^[[:space:]]+versionCode /{print $2; exit}' $ANDROID_BUILD_GRADLE_FILE)
+CURRENT_IOS_VERSION_NUMBER=$(awk -F'[[:space:]=;]+' '/CURRENT_PROJECT_VERSION/{print $3; exit}' $IOS_PROJECT_FILE)
 
 if [[ -z $VERSION_NUMBER ]]; then
   log_and_exit "VERSION_NUMBER not specified, aborting!"
@@ -107,12 +88,17 @@ if ! [[ $VERSION_NUMBER =~ $NAT ]] || [[ $VERSION_NUMBER =~ $SEMVER_REGEX ]]; th
 fi
 
 echo "VERSION_NUMBER is $VERSION_NUMBER."
-echo "CURRENT_VERSION_NUMBER is $CURRENT_VERSION_NUMBER."
+echo "CURRENT_ANDROID_VERSION_NUMBER is $CURRENT_ANDROID_VERSION_NUMBER."
+echo "CURRENT_IOS_VERSION_NUMBER is $CURRENT_IOS_VERSION_NUMBER."
 
-# ensure VERSION_NUMBER goes up
-if [[ "$VERSION_NUMBER" -le "$CURRENT_VERSION_NUMBER" ]]; then
-  echo "version $VERSION_NUMBER is less than or equal to current: $CURRENT_VERSION_NUMBER"
-  exit 1
+# ensure Android version number goes up
+if [[ "$VERSION_NUMBER" -le "$CURRENT_ANDROID_VERSION_NUMBER" ]]; then
+  log_and_exit "Android version $VERSION_NUMBER is less than or equal to current: $CURRENT_ANDROID_VERSION_NUMBER"
+fi
+
+# ensure iOS version number goes up
+if [[ "$VERSION_NUMBER" -le "$CURRENT_IOS_VERSION_NUMBER" ]]; then
+  log_and_exit "iOS version $VERSION_NUMBER is less than or equal to current: $CURRENT_IOS_VERSION_NUMBER"
 fi
 
 echo "VERSION_NUMBER is valid."

--- a/.github/scripts/set-semvar-version.sh
+++ b/.github/scripts/set-semvar-version.sh
@@ -2,7 +2,7 @@
 
 # Script to update semantic versioning across MetaMask platform files
 # This script handles version updates for both mobile and extension platforms
-# For mobile: Updates package.json, Android build.gradle, Bitrise config, and iOS project files
+# For mobile: Updates package.json, Android build.gradle, and iOS project files
 # For extension: Updates package.json only
 
 set -e
@@ -36,7 +36,6 @@ SEMVER_REGEX="\
 # File paths for version updates
 PACKAGE_JSON_FILE=package.json
 ANDROID_BUILD_GRADLE_FILE=android/app/build.gradle
-BITRISE_YML_FILE=bitrise.yml
 IOS_PROJECT_FILE=ios/MetaMask.xcodeproj/project.pbxproj
 
 # Helper Functions
@@ -73,11 +72,6 @@ update_mobile_files () {
     sed -i '' 's/\(\s*versionName \)".*"/\1"'"$SEMVER_VERSION"'"/' "$ANDROID_BUILD_GRADLE_FILE"
     echo "- $ANDROID_BUILD_GRADLE_FILE successfully updated"
 
-    # Update version in Bitrise configuration
-    echo "Updating Bitrise configuration files..."
-    sed -i '' 's/\(\s*VERSION_NAME: \).*/\1'"$SEMVER_VERSION"'/' "$BITRISE_YML_FILE"
-    echo "- $BITRISE_YML_FILE successfully updated"
-
     # Update iOS marketing version
     echo "Updating iOS project settings..."
     sed -i '' 's/\(\s*MARKETING_VERSION = \).*/\1'"$SEMVER_VERSION;"'/' "$IOS_PROJECT_FILE"
@@ -91,11 +85,6 @@ update_mobile_files () {
     sed -i 's/\(\s*versionName \)".*"/\1"'"$SEMVER_VERSION"'"/' "$ANDROID_BUILD_GRADLE_FILE"
     echo "- $ANDROID_BUILD_GRADLE_FILE updated"
 
-    # Update version in Bitrise configuration
-    echo "Updating Bitrise configuration files..."
-    sed -i 's/\(\s*VERSION_NAME: \).*/\1'"$SEMVER_VERSION"'/' "$BITRISE_YML_FILE"
-    echo "- $BITRISE_YML_FILE updated"
-
     # update ios/MetaMask.xcodeproj/project.pbxproj
     echo "Updating iOS project settings..."
     sed -i 's/\(\s*MARKETING_VERSION = \).*/\1'"$SEMVER_VERSION;"'/' "$IOS_PROJECT_FILE"
@@ -104,7 +93,6 @@ update_mobile_files () {
 
   # Print summary of updates
   echo "- $ANDROID_BUILD_GRADLE_FILE updated"
-  echo "- $BITRISE_YML_FILE updated"
   echo "- $IOS_PROJECT_FILE updated"
 
   echo "-------------------"
@@ -123,19 +111,6 @@ fi
 # Validate semantic version format
 if ! [[ $SEMVER_VERSION =~ $SEMVER_REGEX ]]; then
   log_and_exit "$SEMVER_VERSION is invalid semver!"
-fi
-
-# Validate inputs for mobile platform
-if [[ $PLATFORM == "mobile" ]]; then
-  # Get current version numbers from bitrise.yml
-  CURRENT_VERSION_NUMBER=$(awk '/^\s+VERSION_NUMBER: /{print $2}' $BITRISE_YML_FILE);
-  CURRENT_FLASK_VERSION_NUMBER=$(awk '/^\s+FLASK_VERSION_NUMBER: /{print $2}' $BITRISE_YML_FILE);
-
-  # Ensure version number of main variant and flask are aligned
-  if [[ "$CURRENT_VERSION_NUMBER" != "$CURRENT_FLASK_VERSION_NUMBER" ]]; then
-    echo "VERSION_NUMBER $CURRENT_VERSION_NUMBER and FLASK_VERSION_NUMBER $CURRENT_FLASK_VERSION_NUMBER should be the same"
-    log_and_exit "Check why they are different and fix it before proceeding"
-  fi
 fi
 
 echo "SEMVER_VERSION is valid."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Mobile release automation no longer reads from or writes to `bitrise.yml`; the build number (`versionCode` / `CURRENT_PROJECT_VERSION`) and semver (`versionName` / `MARKETING_VERSION`) are now sourced from `android/app/build.gradle` and `ios/MetaMask.xcodeproj/project.pbxproj` directly
+  - `set-semvar-version.sh`, `set-mobile-build-version.sh`, and `create-platform-release-pr.sh` updated accordingly, allowing consumers to remove `bitrise.yml`
+
 ## [1.15.0]
 
 ### Added


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Source mobile version from build.gradle/pbxproj instead of bitrise.yml

Mobile release automation previously read the build number from and wrote version fields into bitrise.yml. This coupled the release flow to a file that is no longer a live Bitrise CI config, so consumers could not remove it.

Source the build number (versionCode / CURRENT_PROJECT_VERSION) and semver (versionName / MARKETING_VERSION) directly from android/app/build.gradle and ios/MetaMask.xcodeproj/project.pbxproj, matching mobile's own scripts/set-build-version.sh. Extension flow is unaffected.

- set-semvar-version.sh: drop bitrise VERSION_NAME write and the bitrise-based build-number alignment check
- set-mobile-build-version.sh: read/write build.gradle + pbxproj, drop bitrise and the flask alignment check
- create-platform-release-pr.sh: drop bitrise.yml from mobile expected files
- stable-sync action: drop bitrise.yml from PR body preservation text

This is a dependency for addressing - https://consensyssoftware.atlassian.net/browse/MCWP-681

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how mobile release CI validates and bumps version numbers; mis-parsed Gradle/pbxproj values or divergent Android/iOS build numbers could block or mis-apply releases until caught in a dry run.
> 
> **Overview**
> Mobile release tooling no longer treats **`bitrise.yml`** as the source of truth for versions, so downstream repos can delete that file.
> 
> **`set-mobile-build-version.sh`** now reads current build numbers from **`android/app/build.gradle`** (`versionCode`) and **`ios/.../project.pbxproj`** (`CURRENT_PROJECT_VERSION`), validates each must increase, and only updates those two files (removed Bitrise `VERSION_NUMBER` / `FLASK_VERSION_NUMBER` writes and the main-vs-Flask alignment check).
> 
> **`set-semvar-version.sh`** stops writing **`VERSION_NAME`** to Bitrise and drops the Bitrise-based build-number alignment guard; mobile semver still updates **`package.json`**, **`versionName`**, and **`MARKETING_VERSION`**.
> 
> **`create-platform-release-pr.sh`** and the **stable-sync** action no longer list **`bitrise.yml`** among expected or preserved mobile files. **CHANGELOG** documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c078686c1f16c51acc5b9a96dc786e06f63631fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->