### PR TITLE
feat: removed schedule trigger from post-relay-subsidy-balance

### DIFF
--- a/.github/workflows/post-relay-subsidy-balance.yml
+++ b/.github/workflows/post-relay-subsidy-balance.yml
@@ -1,9 +1,6 @@
 name: Relay Balances Slack Report
 
 on:
-  schedule:
-    # Every day at 11:53 and 23:53 UTC
-    - cron: '53 11,23 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
Removed the schedule trigger from `post-relay-subsidy-balance.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no changes to job logic, secrets, or application code; the main effect is no automatic twice-daily Slack reports unless someone runs the workflow manually.
> 
> **Overview**
> Stops the **Relay Balances Slack Report** workflow from running on a fixed schedule; it now runs only when triggered manually via **workflow_dispatch**.
> 
> The removed trigger was a daily cron at **11:53** and **23:53 UTC**. The job steps (payload generation and Slack notification) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49317677100579df2b0d3e7ca899d7e39a128afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->