### PR TITLE
fix: prefer manually added team labels over topology lookup

### DIFF
--- a/.github/actions/add-team-label/action.yml
+++ b/.github/actions/add-team-label/action.yml
@@ -1,5 +1,5 @@
 name: Add Team Label
-description: "Adds a GitHub team label to a pull request based on the author's entry in the MetaMask topology file."
+description: "Adds a GitHub team label to a pull request based on the author's entry in the MetaMask topology file. Skips if the PR already has a team-* or external-contributor label."
 
 inputs:
   team-label-token:
@@ -13,9 +13,27 @@ inputs:
 runs:
   using: composite
   steps:
+    # Prefer a manually applied team label (or external-contributor) over topology lookup.
+    - name: Check for existing team label
+      id: check-existing-label
+      env:
+        GH_TOKEN: ${{ inputs.team-label-token }}
+        PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+      shell: bash
+      run: |
+        existing=$(gh pr view "$PULL_REQUEST_URL" --json labels --jq '[.labels[].name] | map(select(startswith("team-") or . == "external-contributor")) | .[0] // empty')
+        if [ -n "$existing" ]; then
+          echo "PR already has team label: $existing — skipping topology assignment"
+          echo "SKIP=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No existing team label — assigning from topology"
+          echo "SKIP=false" >> "$GITHUB_OUTPUT"
+        fi
+
     # Fetch the team label for the PR author from topology.json and expose it as a step output.
     - name: Get team label
       id: get-team-label
+      if: ${{ steps.check-existing-label.outputs.SKIP != 'true' }}
       env:
         GH_TOKEN: ${{ inputs.planning-token || inputs.team-label-token }}
         USER: ${{ github.event.pull_request.user.login }}
@@ -32,6 +50,7 @@ runs:
 
     # Apply the retrieved label to the pull request using the GitHub CLI.
     - name: Add team label
+      if: ${{ steps.check-existing-label.outputs.SKIP != 'true' }}
       env:
         GH_TOKEN: ${{ inputs.team-label-token }}
         PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prefer manually added team labels (or `external-contributor`) over topology lookup in `add-team-label`
+
 ## [1.16.0]
 
 ### Changed


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
## Summary
- Skip topology assignment in `add-team-label` when the PR already has a `team-*` or `external-contributor` label
- Keeps manually applied team labels from being layered over by the author's topology match
- Logs both skip and assign paths for clearer Actions output
 Fixes: [MCRM-72](https://consensyssoftware.atlassian.net/browse/MCRM-72?atlOrigin=eyJpIjoiNGMyMjQxYTE0Y2ZkNDgyN2FhMDIxNzNjOTllN2RmODMiLCJwIjoiaiJ9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to PR labeling automation in GitHub Actions; no application runtime or security-sensitive logic.
> 
> **Overview**
> The **`add-team-label`** composite action no longer overwrites PRs that already have a **`team-*`** or **`external-contributor`** label.
> 
> A new first step reads current labels via **`gh pr view`**; if one of those labels is present, topology lookup and label application are skipped (with log lines for skip vs assign). **`Get team label`** and **Add team label** run only when no such label exists. The action description and **CHANGELOG** document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d33716f079b295f21e8ba60b5d78f30e19e557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->