### PR TITLE
fix: pass github-token to primary checkout in stable-sync action

### DIFF
--- a/.github/actions/stable-sync/action.yml
+++ b/.github/actions/stable-sync/action.yml
@@ -31,6 +31,7 @@ runs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        token: ${{ inputs.github-token }}
 
     - name: Checkout GitHub tools repository
       uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

`stable-sync`'s first `actions/checkout` step (checking out the consuming repo, e.g. `metamask-mobile`) never forwards the action's own `github-token` input. It relies on `actions/checkout`'s default (`github.token`), which is only as privileged as the calling job's `permissions:` block.

`metamask-mobile`'s `stable-branch-sync.yml` migrated to OIDC token exchange (#32331 there), and its `run-stable-sync` job now scopes its own `permissions:` down to just `id-token: write`. Job-level `permissions:` replaces (not merges with) the workflow-level block, so the default `GITHUB_TOKEN` for that job has no `contents: write` — it's read-only (`Metadata: read`).

Meanwhile the elevated, narrowly-scoped token obtained via OIDC exchange is passed into this action as `github-token`, but is only wired into the final `gh pr create` step. The checkout step (whose persisted git credentials are what `git push` at the end of this action actually uses) never sees it.

Net effect: the branch push at the end of `run-stable-sync` fails every time with:

```
remote: Permission to <repo>.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

Since that step fails, the following `Create Pull Request` step is skipped, so no `stable -> main` sync PR is ever opened. This has been silently broken for `metamask-mobile` since ~2026-07-13 (once the OIDC-migrated workflow reached its `stable` branch) — see runs [29279657644](https://github.com/MetaMask/metamask-mobile/actions/runs/29279657644), [29439944223](https://github.com/MetaMask/metamask-mobile/actions/runs/29439944223), [29787290543](https://github.com/MetaMask/metamask-mobile/actions/runs/29787290543), [30291849225](https://github.com/MetaMask/metamask-mobile/actions/runs/30291849225), [30655332762](https://github.com/MetaMask/metamask-mobile/actions/runs/30655332762), [31421433607](https://github.com/MetaMask/metamask-mobile/actions/runs/31421433607).

## Fix

Pass `token: ${{ inputs.github-token }}` on the primary checkout, matching the sibling `release-branch-sync` action, which already does this correctly and has never had this issue:

```yaml
- name: Checkout repository
  uses: actions/checkout@v6
  with:
    fetch-depth: 0
    token: ${{ inputs.github-token }}
```

## Follow-up (in metamask-mobile, not part of this PR)

Once a new tag is cut with this fix, `metamask-mobile`'s `.github/workflows/stable-branch-sync.yml` needs its `stable-sync@v1.16.0` pin bumped to pick it up, and a `stable` push (or manual re-run) will be needed to generate the missing `stable-main-X.Y.Z -> main` sync PR(s).

## Test plan

- [ ] Cut a new tag including this change
- [ ] Bump the pin in a consuming workflow (e.g. `metamask-mobile`'s `stable-branch-sync.yml`) and re-run/push to confirm the checkout now persists the elevated token and the branch push + PR creation succeed

Made with [Cursor](https://cursor.com)