### PR TITLE
bump: auto-changelog to 6.2.0

### DIFF
--- a/.github/scripts/update-release-changelog.sh
+++ b/.github/scripts/update-release-changelog.sh
@@ -145,13 +145,9 @@ checkout_or_create_branch "${CHANGELOG_BRANCH}" "${RELEASE_BRANCH}"
 
 echo "Generating changelog for ${PLATFORM} ${VERSION}.."
 
-yarn auto-changelog update --rc \
+yarn update-changelog \
     --repo "${GITHUB_REPOSITORY_URL}" \
-    --currentVersion "${VERSION}" \
-    --autoCategorize \
-    --useChangelogEntry \
-    --useShortPrLink \
-    --requirePrNumbers
+    --currentVersion "${VERSION}"
 
 # commits.csv generation removed (no longer required)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "update-release-sheet": "node .github/scripts/update-release-sheet.mjs"
   },
   "dependencies": {
-    "@metamask/auto-changelog": "^5.3.2",
+    "@metamask/auto-changelog": "^6.2.0",
     "@metamask/utils": "^7.1.0",
     "@octokit/graphql": "^7.0.1",
     "@octokit/request": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,9 +941,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/auto-changelog@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "@metamask/auto-changelog@npm:5.3.2"
+"@metamask/auto-changelog@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "@metamask/auto-changelog@npm:6.2.0"
   dependencies:
     "@octokit/rest": "npm:^20.0.0"
     diff: "npm:^5.0.0"
@@ -951,10 +951,16 @@ __metadata:
     semver: "npm:^7.3.5"
     yargs: "npm:^17.0.1"
   peerDependencies:
+    oxfmt: ^0.45.0
     prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    oxfmt:
+      optional: true
+    prettier:
+      optional: true
   bin:
     auto-changelog: dist/cli.mjs
-  checksum: 10/21c993fae0af9bf4d219d52f1c28ab364e6844c4ab93f987a4db3a3df66f0e0c9a0c8a69c130bcb3ecd535e4a9b45a6e8059e95879ac652f9978dba198dd0ec1
+  checksum: 10/9cefcf494dd68d0ee689b54f159a2b78ed41ceb5964288f7237a470f88a1beabb4d4f6c28c596ae4960af2285c95713bea3b75931e632d0aa8923c89d2484b6d
   languageName: node
   linkType: hard
 
@@ -1014,7 +1020,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^2.3.1"
     "@lavamoat/preinstall-always-fail": "npm:^1.0.0"
-    "@metamask/auto-changelog": "npm:^5.3.2"
+    "@metamask/auto-changelog": "npm:^6.2.0"
     "@metamask/eslint-config": "npm:^12.0.0"
     "@metamask/eslint-config-jest": "npm:^12.0.0"
     "@metamask/eslint-config-nodejs": "npm:^12.0.0"


### PR DESCRIPTION
Bump auto-changelog to 6.2.0, and make the clients responsible for their own flags.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release changelog output depends on each target repo defining `update-changelog` correctly; a missing or misconfigured script would break release automation.
> 
> **Overview**
> Upgrades **`@metamask/auto-changelog`** from **5.3.2** to **6.2.0** (lockfile included; v6 adds optional **`oxfmt`** / **`prettier`** peer deps).
> 
> Release changelog automation in **`update-release-changelog.sh`** no longer runs **`auto-changelog update --rc`** with shared flags (`--autoCategorize`, `--useChangelogEntry`, `--useShortPrLink`, `--requirePrNumbers`). It now invokes **`yarn update-changelog`** with only **`--repo`** and **`--currentVersion`**, so each platform repo’s **`update-changelog`** script owns how changelog generation is configured on v6.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea75434a3eb773f73b8104f020ebff185007eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->