### PR TITLE
fix: restore backwards compatibility for auto-changelog

### DIFF
--- a/.github/scripts/update-release-changelog.sh
+++ b/.github/scripts/update-release-changelog.sh
@@ -145,9 +145,22 @@ checkout_or_create_branch "${CHANGELOG_BRANCH}" "${RELEASE_BRANCH}"
 
 echo "Generating changelog for ${PLATFORM} ${VERSION}.."
 
-yarn update-changelog \
+# Use the calling repository's changelog policy when it defines the script.
+# Preserve the legacy invocation for consumers that have not adopted it yet.
+if yarn run --silent update-changelog --help >/dev/null 2>&1; then
+  yarn update-changelog \
     --repo "${GITHUB_REPOSITORY_URL}" \
     --currentVersion "${VERSION}"
+else
+  echo "No update-changelog script found; using legacy auto-changelog invocation." >&2
+  yarn auto-changelog update --rc \
+    --repo "${GITHUB_REPOSITORY_URL}" \
+    --currentVersion "${VERSION}" \
+    --autoCategorize \
+    --useChangelogEntry \
+    --useShortPrLink \
+    --requirePrNumbers
+fi
 
 # commits.csv generation removed (no longer required)
 


### PR DESCRIPTION
Use the calling repo's `update-changelog` if it's present, otherwise go back to previous behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release automation change with a clear feature-detect fallback; no runtime app or security impact.
> 
> **Overview**
> **Release changelog automation** no longer assumes every consumer defines a `update-changelog` Yarn script.
> 
> `update-release-changelog.sh` now probes `yarn update-changelog --help` and uses that wrapper when the calling repo provides it. Repos without that script get the **previous** behavior: a direct `yarn auto-changelog update --rc` run with `--autoCategorize`, `--useChangelogEntry`, `--useShortPrLink`, and `--requirePrNumbers`, plus a stderr notice that the legacy path is in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba14d6e64d7da9bd344bff38612ab56658b03d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->