### PR TITLE
fix(publish-preview): include `.yarn/patches` in preview build artifacts

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -184,7 +184,7 @@ jobs:
           include-hidden-files: true
           retention-days: ${{ inputs.artifact-retention-days }}
           path: |
-            ./.yarn/patches/*/
+            ./.yarn/patches/*
             ./yarn.lock
             ./package.json
             ./packages/*/

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -184,6 +184,7 @@ jobs:
           include-hidden-files: true
           retention-days: ${{ inputs.artifact-retention-days }}
           path: |
+            ./.yarn/patches/*/
             ./yarn.lock
             ./package.json
             ./packages/*/


### PR DESCRIPTION
The `publish-preview` job re-runs `yarn install --no-immutable` after restoring the monorepo build artifact uploaded by `build-preview`. That artifact previously did not include the `.yarn/patches` directory, so for consumer repositories with a patched dependency the install failed because the patch files referenced in `yarn.lock` were missing on disk.

This adds `.yarn/patches/*/` to the monorepo build artifact's upload path, alongside `yarn.lock` and `package.json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI artifact path change only; no runtime or auth logic touched.
> 
> **Overview**
> **Fixes monorepo preview publishes** when dependencies use Yarn patch protocol entries in `yarn.lock`.
> 
> The `build-preview` job’s monorepo artifact upload now includes **`./.yarn/patches/*`** next to `yarn.lock` and `package.json`. The downstream `publish-preview` step runs `yarn install --no-immutable` on the restored artifact; without those patch files on disk, install previously failed for patched packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc01df1c7e815c7fbe4ad8878f243be5a80f624c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->