### PR TITLE
feat: add authorize-commenter action

### DIFF
--- a/.github/actions/authorize-commenter/action.yml
+++ b/.github/actions/authorize-commenter/action.yml
@@ -14,8 +14,8 @@ description: >-
   head or merge ref runs untrusted code with the privileges the gate was
   protecting.
 
-  The token must be able to read collaborator permissions, which the default
-  `GITHUB_TOKEN` may not be. If it cannot, this action fails, so an
+  The default `GITHUB_TOKEN` can read collaborator permissions with no more
+  than `contents: read`. If a token ever cannot, this action fails, so an
   underpowered token denies everyone rather than quietly authorizing them.
 
 inputs:

--- a/.github/actions/authorize-commenter/action.yml
+++ b/.github/actions/authorize-commenter/action.yml
@@ -1,15 +1,22 @@
 name: Authorize commenter
 description: >-
-  Check whether the author of a comment has write access to the repository.
+  Check that the author of a comment has write access to the repository, and
+  fail if they do not.
 
   Workflows triggered by `issue_comment` run from the default branch with
   access to secrets, so gating them on the comment body alone lets anyone who
-  can comment start them. Use this action as the first job of such a workflow
-  and make the privileged jobs depend on it.
+  can comment start them. Run this action as the first job of such a workflow
+  and give every privileged job `needs` on that job. A failed dependency skips
+  the jobs that need it, so there is no condition to forget.
 
-  The check fails closed, so if the permission cannot be read then nobody is
-  authorized. The token must be able to read collaborator permissions, which
-  the default `GITHUB_TOKEN` may not be.
+  This authorizes the person who wrote the comment, not the code they wrote it
+  on. A workflow that passes this gate and then checks out the pull request
+  head or merge ref runs untrusted code with the privileges the gate was
+  protecting.
+
+  The token must be able to read collaborator permissions, which the default
+  `GITHUB_TOKEN` may not be. If it cannot, this action fails, so an
+  underpowered token denies everyone rather than quietly authorizing them.
 
 inputs:
   username:
@@ -24,16 +31,10 @@ inputs:
     required: true
     default: ${{ github.token }}
 
-outputs:
-  authorized:
-    value: ${{ steps.authorize.outputs.authorized || 'false' }}
-    description: Whether the user has write access to the repository.
-
 runs:
   using: composite
   steps:
     - name: Check the commenter's repository permission
-      id: authorize
       uses: actions/github-script@v9
       env:
         USERNAME: ${{ inputs.username }}
@@ -46,15 +47,19 @@ runs:
             return core.setFailed('No username to authorize. Pass `username`, or run this action on an event that has a comment author.');
           }
 
-          // `permission` collapses custom roles onto admin/write/read/none, so
-          // write and admin are exactly the people who can push to the repo.
-          // On a public repository everyone else reads back as `read`, so
-          // there is no "not a collaborator" error case to handle.
+          // `permission` collapses custom roles onto admin, write, read and
+          // none, so admin and write are exactly the logins that can push.
+          // Everyone else reads back as `read` on a public repository and
+          // `none` on a private one. A login that no longer resolves, such as
+          // `ghost`, raises instead, which fails this step rather than
+          // authorizing.
           const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
             ...context.repo,
             username: USERNAME,
           });
 
-          const authorized = ['admin', 'write'].includes(data.permission);
-          core.info(`${USERNAME} has ${data.permission} permission, ${authorized ? 'authorized' : 'not authorized'}.`);
-          core.setOutput('authorized', String(authorized));
+          if (!['admin', 'write'].includes(data.permission)) {
+            return core.setFailed(`@${USERNAME} has ${data.permission} permission on this repository, which is not enough to run this command.`);
+          }
+
+          core.info(`@${USERNAME} has ${data.permission} permission.`);

--- a/.github/actions/authorize-commenter/action.yml
+++ b/.github/actions/authorize-commenter/action.yml
@@ -1,0 +1,60 @@
+name: Authorize commenter
+description: >-
+  Check whether the author of a comment has write access to the repository.
+
+  Workflows triggered by `issue_comment` run from the default branch with
+  access to secrets, so gating them on the comment body alone lets anyone who
+  can comment start them. Use this action as the first job of such a workflow
+  and make the privileged jobs depend on it.
+
+  The check fails closed, so if the permission cannot be read then nobody is
+  authorized. The token must be able to read collaborator permissions, which
+  the default `GITHUB_TOKEN` may not be.
+
+inputs:
+  username:
+    description: The login to authorize. Defaults to the author of the comment
+      that triggered the workflow.
+    required: true
+    default: ${{ github.event.comment.user.login }}
+
+  github-token:
+    description: The GitHub token to use for authentication. Defaults to the
+      standard GITHUB_TOKEN.
+    required: true
+    default: ${{ github.token }}
+
+outputs:
+  authorized:
+    value: ${{ steps.authorize.outputs.authorized || 'false' }}
+    description: Whether the user has write access to the repository.
+
+runs:
+  using: composite
+  steps:
+    - name: Check the commenter's repository permission
+      id: authorize
+      uses: actions/github-script@v9
+      env:
+        USERNAME: ${{ inputs.username }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const { USERNAME } = process.env;
+
+          if (!USERNAME) {
+            return core.setFailed('No username to authorize. Pass `username`, or run this action on an event that has a comment author.');
+          }
+
+          // `permission` collapses custom roles onto admin/write/read/none, so
+          // write and admin are exactly the people who can push to the repo.
+          // On a public repository everyone else reads back as `read`, so
+          // there is no "not a collaborator" error case to handle.
+          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+            ...context.repo,
+            username: USERNAME,
+          });
+
+          const authorized = ['admin', 'write'].includes(data.permission);
+          core.info(`${USERNAME} has ${data.permission} permission, ${authorized ? 'authorized' : 'not authorized'}.`);
+          core.setOutput('authorized', String(authorized));

--- a/.github/workflows/test-authorize-commenter.yml
+++ b/.github/workflows/test-authorize-commenter.yml
@@ -1,0 +1,36 @@
+name: Test "Authorize Commenter" Action
+
+# Temporary. This exists to confirm that the default GITHUB_TOKEN can read
+# collaborator permissions. Remove it, or wire it into main.yml as a permanent
+# test, once that question is settled.
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: A login with write access is authorized
+        uses: ./.github/actions/authorize-commenter
+        with:
+          username: ${{ github.actor }}
+
+      - name: A login without write access is refused
+        id: refused
+        continue-on-error: true
+        uses: ./.github/actions/authorize-commenter
+        with:
+          username: octocat
+
+      - name: Fail if the refusal did not happen
+        if: steps.refused.outcome != 'failure'
+        run: |
+          echo "Expected octocat to be refused, but the action succeeded."
+          exit 1

--- a/.github/workflows/test-authorize-commenter.yml
+++ b/.github/workflows/test-authorize-commenter.yml
@@ -1,8 +1,7 @@
 name: Test "Authorize Commenter" Action
 
-# Temporary. This exists to confirm that the default GITHUB_TOKEN can read
-# collaborator permissions. Remove it, or wire it into main.yml as a permanent
-# test, once that question is settled.
+# Unlike the other test-*.yml workflows, this one triggers directly rather than
+# through workflow_call, so that it actually runs on every pull request.
 
 on: pull_request
 
@@ -17,7 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Skipped on forks, where the author has read access and would be refused.
       - name: A login with write access is authorized
+        if: github.event.pull_request.head.repo.fork == false
         uses: ./.github/actions/authorize-commenter
         with:
           username: ${{ github.actor }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `authorize-commenter` action, which checks whether the author of a comment has write access to the repository, so that `issue_comment` triggered workflows can refuse to run privileged steps for someone who only has read access ([#286](https://github.com/MetaMask/github-tools/pull/286))
+- Add `authorize-commenter` action, which fails unless the author of a comment has write access to the repository, so that `issue_comment` triggered workflows can refuse to run privileged jobs for someone who only has read access ([#286](https://github.com/MetaMask/github-tools/pull/286))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `authorize-commenter` action, which checks whether the author of a comment has write access to the repository, so that `issue_comment` triggered workflows can refuse to run privileged steps for someone who only has read access ([#PR](https://github.com/MetaMask/github-tools/pull/PR))
+- Add `authorize-commenter` action, which checks whether the author of a comment has write access to the repository, so that `issue_comment` triggered workflows can refuse to run privileged steps for someone who only has read access ([#286](https://github.com/MetaMask/github-tools/pull/286))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `authorize-commenter` action, which checks whether the author of a comment has write access to the repository, so that `issue_comment` triggered workflows can refuse to run privileged steps for someone who only has read access ([#PR](https://github.com/MetaMask/github-tools/pull/PR))
+
 ### Fixed
 
 - Count changed lines in `pr-line-check` from the pull request files API, so the count always reflects the pull request's current base branch ([#273](https://github.com/MetaMask/github-tools/pull/273))


### PR DESCRIPTION
Workflows triggered by `issue_comment` run from the default branch with access to secrets. The two in `MetaMask/core` that use them, `update-changelogs` and `publish-preview`, gate only on the comment body, so on a public repository anyone who can comment can start them. `publish-preview` publishes to npm. There is nothing shared to check the commenter, so today each workflow would have to grow its own copy of the check.

This adds an `authorize-commenter` action. It reads the commenter's repository permission and fails unless that permission is `write` or `admin`. A workflow runs it as its first job and gives every privileged job `needs` on that job, so a refusal skips them.

A few notes on the choices:

* It fails rather than returning an `authorized` output. Action outputs are strings, and every non empty string is truthy in a workflow expression, so a consumer writing the natural `if: needs.authorize.outputs.authorized` would get `'false'` and a wide open gate. Failing removes the trap instead of documenting around it, and it means the integration is just `needs`, with no condition to forget.
* It uses the permission API rather than `github.event.comment.author_association`. The association returns `NONE` for org members whose membership is private, and its `COLLABORATOR` value does not distinguish a read only collaborator from one who can push.
* The `permission` field collapses custom roles onto admin, write, read and none, so admin and write are exactly the logins that can push. Everyone else reads back as `read` on a public repository and `none` on a private one.
* The default `GITHUB_TOKEN` is enough. I was unsure whether that endpoint would need a token minted by `get-token`, so I tested it: with only `contents: read` it reads `write` for a maintainer and `read` for `octocat`. See the run on this pull request.

`test-authorize-commenter.yml` covers both directions, a login with write access being authorized and `octocat` being refused. It triggers on `pull_request` directly rather than through `workflow_call` like the other `test-*.yml` workflows, because those are not wired into `main.yml` and so never run. The positive case is skipped on fork pull requests, where the author legitimately has read access.

Worth knowing for whoever adopts this: it authorizes the person who wrote the comment, not the code they wrote it on. A workflow that passes this gate and then checks out the pull request head or merge ref runs untrusted code with exactly the privileges the gate was protecting. That caveat is in the action description too.

Adoption in `MetaMask/core` will be a separate pull request covering both workflows. See MetaMask/core#10077, where this came up.
